### PR TITLE
geth migration `transaction`

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -200,7 +200,7 @@ func TestAPI_Core_GetTransactionReceipt(t *testing.T) {
 		)
 
 		assert.Nil(t, err)
-		assert.Equal(t, res.TransactionHash, txHash)
+		assert.Equal(t, res.TxHash.Hex(), txHash)
 	})
 }
 

--- a/constant/errors.go
+++ b/constant/errors.go
@@ -33,4 +33,5 @@ var (
 	ErrResultIsNil                      = errors.New("result is nil")
 	ErrFailedToCreateRequestBody        = errors.New("failed to create request body")
 	ErrInvalidArgs                      = errors.New("invalid args")
+	ErrOverFlow                         = errors.New("overflow")
 )

--- a/docs/docs/core-namespace/EstimateGas.md
+++ b/docs/docs/core-namespace/EstimateGas.md
@@ -10,14 +10,14 @@ func EstimateGas(tx types.TransactionRequest) (price *big.Int, err error)
 
 ```go
 func main() {
-  ...
-  alchemy := gas.NewAlchemy(setting)
-  res, _ := alchemy.Core.EstimateGas(
-    types.TransactionRequest{
-      From:  "0x44aa93095d6749a706051658b970b941c72c1d53",
-      To:    "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73",
-      Value: "0x1",
-    },
-  )
+	...
+	alchemy := gas.NewAlchemy(setting)
+	res, _ := alchemy.Core.EstimateGas(
+		types.TransactionRequest{
+			From:  "0x44aa93095d6749a706051658b970b941c72c1d53",
+			To:    "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73",
+			Value: "0x1",
+		},
+	)
 }
 ```

--- a/docs/docs/core-namespace/GetBlock.md
+++ b/docs/docs/core-namespace/GetBlock.md
@@ -3,7 +3,9 @@
 Returns the block from the network based on the provided block number or hash.
 Transactions on the block are represented as an array of transaction hashes.
 
-refs: https://github.com/ethereum/go-ethereum/blob/master/core/types/block.go#L206
+- types: `*types.Block`
+
+  - refs: https://github.com/ethereum/go-ethereum/blob/master/core/types/block.go#L206
 
 ```go
 func GetBlock(blockHashOrBlockTag types.BlockHashOrBlockTag) (block *types.Block, err error)
@@ -11,14 +13,14 @@ func GetBlock(blockHashOrBlockTag types.BlockHashOrBlockTag) (block *types.Block
 
 ```go
 func main() {
-  ...
-  alchemy := gas.NewAlchemy(setting)
-  res, _ := alchemy.Core.GetBlock(types.BlockHashOrBlockTag{
-    BlockHash: "0xf7756d836b6716aaeffc2139c032752ba5acf02fe94acb65743f0d177554b2e2",
-  })
+	...
+	alchemy := gas.NewAlchemy(setting)
+	res, _ := alchemy.Core.GetBlock(types.BlockHashOrBlockTag{
+		BlockHash: "0xf7756d836b6716aaeffc2139c032752ba5acf02fe94acb65743f0d177554b2e2",
+	})
 
-  res, _ = alchemy.Core.GetBlock(types.BlockHashOrBlockTag{
-    BlockTag: "0x123",
-  })
+	res, _ = alchemy.Core.GetBlock(types.BlockHashOrBlockTag{
+		BlockTag: "0x123",
+	})
 }
 ```

--- a/docs/docs/core-namespace/GetBlockNumber.md
+++ b/docs/docs/core-namespace/GetBlockNumber.md
@@ -8,8 +8,8 @@ func GetBlockNumber() (blockNumber uint64, err error)
 
 ```go
 func main() {
-  ...
-  alchemy := gas.NewAlchemy(setting)
-  res, _ := alchemy.Core.GetBlockNumber()
+	...
+	alchemy := gas.NewAlchemy(setting)
+	res, _ := alchemy.Core.GetBlockNumber()
 }
 ```

--- a/docs/docs/core-namespace/GetGasPrice.md
+++ b/docs/docs/core-namespace/GetGasPrice.md
@@ -8,8 +8,8 @@ func GetGasPrice() (price *big.Int, err error)
 
 ```go
 func main() {
-  ...
-  alchemy := gas.NewAlchemy(setting)
-  res, _ := alchemy.Core.GetGasPrice()
+	...
+	alchemy := gas.NewAlchemy(setting)
+	res, _ := alchemy.Core.GetGasPrice()
 }
 ```

--- a/docs/docs/core-namespace/GetTransactionReceipt.md
+++ b/docs/docs/core-namespace/GetTransactionReceipt.md
@@ -4,18 +4,20 @@ Null if the tx has not been mined.
 Returns the transaction receipt for hash.
 To stall until the transaction has been mined, consider the waitForTransaction method below.
 
-refs: https://github.com/ethereum/go-ethereum/blob/master/core/types/receipt.go#L53
+- types: `*types.Receipt`
+
+  - refs: https://github.com/ethereum/go-ethereum/blob/master/core/types/receipt.go#L53
 
 ```go
-func GetTransactionReceipt(hash string) (txReceipt *gethTypes.Receipt, err error)
+func GetTransactionReceipt(hash string) (txReceipt *types.Receipt, err error)
 ```
 
 ```go
 func main() {
-  ...
-  alchemy := gas.NewAlchemy(setting)
-  res, _ := alchemy.Core.GetTransactionReceipt(
-    "0xc11dacdf03d9fd9297e3a005560e8855608dde8534d9b1053f6608b8541623b8",
-  )
+	...
+	alchemy := gas.NewAlchemy(setting)
+	res, _ := alchemy.Core.GetTransactionReceipt(
+		"0xc11dacdf03d9fd9297e3a005560e8855608dde8534d9b1053f6608b8541623b8",
+	)
 }
 ```

--- a/docs/docs/core-namespace/GetTransactionReceipt.md
+++ b/docs/docs/core-namespace/GetTransactionReceipt.md
@@ -1,0 +1,21 @@
+![](https://img.shields.io/badge/go-geth-lightblue)
+
+Null if the tx has not been mined.
+Returns the transaction receipt for hash.
+To stall until the transaction has been mined, consider the waitForTransaction method below.
+
+refs: https://github.com/ethereum/go-ethereum/blob/master/core/types/receipt.go#L53
+
+```go
+func GetTransactionReceipt(hash string) (txReceipt *gethTypes.Receipt, err error)
+```
+
+```go
+func main() {
+  ...
+  alchemy := gas.NewAlchemy(setting)
+  res, _ := alchemy.Core.GetTransactionReceipt(
+    "0xc11dacdf03d9fd9297e3a005560e8855608dde8534d9b1053f6608b8541623b8",
+  )
+}
+```

--- a/docs/docs/core-namespace/GetTransactionReceipts.md
+++ b/docs/docs/core-namespace/GetTransactionReceipts.md
@@ -1,0 +1,26 @@
+An enhanced API that gets all transaction receipts for a given block by number or block hash.
+Returns geth's Receipt.
+
+- types: `*types.Receipt`
+
+  - refs: https://github.com/ethereum/go-ethereum/blob/master/core/types/receipt.go#L53
+
+- method: `alchemy_getTransactionReceipts`
+
+  - refs: https://www.alchemy.com/docs/data/utility-apis/transactions-receipts-endpoints/alchemy-get-transaction-receipts
+
+```go
+func GetTransactionReceipts(arg types.TransactionReceiptsArg) (receipts []*types.Receipt, err error)
+```
+
+```go
+func main() {
+	...
+	alchemy := gas.NewAlchemy(setting)
+	res, err := alchemy.Core.GetTransactionReceipts(
+		types.TransactionReceiptsArg{
+			BlockNumber: "0xF1D1C6",
+		},
+	)
+}
+```

--- a/ether/ether_core_test.go
+++ b/ether/ether_core_test.go
@@ -1045,104 +1045,41 @@ var expectedTransactionReceipt = `
 `
 
 func Test_GetTransactionReceipt(t *testing.T) {
-	provider := newProviderForTest()
-	ether := newNilEtherApiForTest(provider)
-
-	t.Run("normal case: ", func(t *testing.T) {
-		t.Run("call eth_getTransactionReceipt & return result", func(t *testing.T) {
-			patches := gomonkey.NewPatches()
-			defer patches.Reset()
-
-			// Arrange
-			transactionHash := "hash"
-			expected := types.TransactionReceipt{
-				TransactionHash:   "0x504ce587a65bdbdb6414a0c6c16d86a04dd79bfcc4f2950eec9634b30ce5370f",
-				TransactionIndex:  "0x0",
-				BlockHash:         "0xe7212a92cfb9b06addc80dec2a0dfae9ea94fd344efeb157c41e12994fcad60a",
-				BlockNumber:       "0x50",
-				From:              "0x627306090abab3a6e1400e9345bc60c78a8bef57",
-				To:                "0xf17f52151ebef6c7334fad080c5704d77216b732",
-				CumulativeGasUsed: "0x5208",
-				GasUsed:           "0x5208",
-				Logs:              []types.LogResponse{},
-				LogsBloom:         "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-				EffectiveGasPrice: "0x1",
-				Type:              "0x0",
-				Status:            "0x1",
-			}
-
-			// Mock
-			patches.ApplyMethod(
-				reflect.TypeOf(provider),
-				"Send",
-				func(_ *gas.AlchemyProvider, method string, _ types.RequestArgs) (any, error) {
-					assert.Equal(t, constant.Eth_GetTransactionReceipt, method)
-					var result map[string]any
-					json.Unmarshal([]byte(expectedTransactionReceipt), &result)
-					return result, nil
-				},
-			)
-
-			// Act
-			res, err := ether.GetTransactionReceipt(transactionHash)
-
-			// Assert
-			assert.Nil(t, err)
-			assert.Equal(t, expected, res)
-		})
-	})
-
 	t.Run("error case:", func(t *testing.T) {
-		t.Run("if error on send, return internal error", func(t *testing.T) {
+		t.Run("if internal error, return error", func(t *testing.T) {
+			// Arrange
+			ether := newEtherApiForTest()
+			txHash := "hash"
+
+			// Act
+			_, err := ether.GetTransactionReceipt(txHash)
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if cannot create ethClient, return err", func(t *testing.T) {
 			patches := gomonkey.NewPatches()
 			defer patches.Reset()
 
 			// Arrange
-			expectedErr := errors.New("error")
+			ether := newEtherApiForTest()
+			txHash := "hash"
 
 			// Mock
 			patches.ApplyMethod(
-				reflect.TypeOf(provider),
-				"Send",
-				func(_ *gas.AlchemyProvider, method string, _ types.RequestArgs) (any, error) {
-					return "", expectedErr
+				reflect.TypeOf(ether),
+				"GetEthClient",
+				func(_ *eth.Ether) (*ethclient.Client, error) {
+					return nil, errors.New("error")
 				},
 			)
 
 			// Act
-			_, err := ether.GetTransactionReceipt("hash")
+			_, err := ether.GetTransactionReceipt(txHash)
 
 			// Assert
-			assert.ErrorIs(t, err, expectedErr)
-		})
-
-		t.Run("if map structure failed, return constant.ErrFailedToMapTransactionReceipt", func(t *testing.T) {
-			patches := gomonkey.NewPatches()
-			defer patches.Reset()
-
-			// Mock
-			patches.ApplyMethod(
-				reflect.TypeOf(provider),
-				"Send",
-				func(_ *gas.AlchemyProvider, method string, _ types.RequestArgs) (any, error) {
-					assert.Equal(t, constant.Eth_GetTransactionReceipt, method)
-					var result map[string]any
-					json.Unmarshal([]byte(expectedTransactionReceipt), &result)
-					return result, nil
-				},
-			)
-			patches.ApplyFunc(
-				mapstructure.Decode,
-				func(_ any, _ any) error {
-					return errors.New("error")
-				},
-			)
-
-			// Act
-			_, err := ether.GetTransactionReceipt("0x123")
-
-			// Assert
-			assert.ErrorIs(t, constant.ErrFailedToMapTransactionReceipt, err)
+			assert.Error(t, err)
 		})
 	})
 }

--- a/ether/ether_core_test.go
+++ b/ether/ether_core_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/agiledragon/gomonkey"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/goccy/go-json"
@@ -1112,7 +1113,7 @@ func Test_GetTransactionReceipts(t *testing.T) {
 	ether := newNilEtherApiForTest(provider)
 
 	t.Run("normal case: ", func(t *testing.T) {
-		expected := []types.TransactionReceipt{
+		expectedAlchemyReceipt := []types.TransactionReceipt{
 			{
 				TransactionHash:   "0x504ce587a65bdbdb6414a0c6c16d86a04dd79bfcc4f2950eec9634b30ce5370f",
 				TransactionIndex:  "0x0",
@@ -1129,6 +1130,9 @@ func Test_GetTransactionReceipts(t *testing.T) {
 				Status:            "0x1",
 			},
 		}
+
+		expected := make([]*gethTypes.Receipt, 1)
+		expected[0], _ = utils.TransformAlchemyReceiptToGeth(expectedAlchemyReceipt[0])
 
 		t.Run("call alchemy_getTransactionReceipts & return result, blockHash pattern", func(t *testing.T) {
 			patches := gomonkey.NewPatches()

--- a/namespace/core_namespace.go
+++ b/namespace/core_namespace.go
@@ -84,8 +84,9 @@ type ICore interface {
 
 	/*
 		An enhanced API that gets all transaction receipts for a given block by number or block hash.
+		Returns geth's Receipt.
 	*/
-	GetTransactionReceipts(arg types.TransactionReceiptsArg) ([]types.TransactionReceipt, error)
+	GetTransactionReceipts(arg types.TransactionReceiptsArg) ([]*gethTypes.Receipt, error)
 
 	/*
 		Returns the block from the network based on the provided block number or hash.
@@ -226,10 +227,10 @@ func (c *Core) GetTransactionReceipt(hash string) (*gethTypes.Receipt, error) {
 	return receipt, nil
 }
 
-func (c *Core) GetTransactionReceipts(arg types.TransactionReceiptsArg) ([]types.TransactionReceipt, error) {
+func (c *Core) GetTransactionReceipts(arg types.TransactionReceiptsArg) ([]*gethTypes.Receipt, error) {
 	receipts, err := c.ether.GetTransactionReceipts(arg)
 	if err != nil {
-		return []types.TransactionReceipt{}, err
+		return []*gethTypes.Receipt{}, err
 	}
 
 	return receipts, nil

--- a/namespace/core_namespace.go
+++ b/namespace/core_namespace.go
@@ -76,11 +76,11 @@ type ICore interface {
 	Call(tx types.TransactionRequest, blockTag string) (string, error)
 
 	/*
-		TODO: null if the tx has not been mined.
+		Null if the tx has not been mined.
 		Returns the transaction receipt for hash.
 		To stall until the transaction has been mined, consider the waitForTransaction method below.
 	*/
-	GetTransactionReceipt(hash string) (types.TransactionReceipt, error)
+	GetTransactionReceipt(hash string) (*gethTypes.Receipt, error)
 
 	/*
 		An enhanced API that gets all transaction receipts for a given block by number or block hash.
@@ -217,10 +217,10 @@ func (c *Core) Call(tx types.TransactionRequest, blockTag string) (string, error
 	return result, nil
 }
 
-func (c *Core) GetTransactionReceipt(hash string) (types.TransactionReceipt, error) {
+func (c *Core) GetTransactionReceipt(hash string) (*gethTypes.Receipt, error) {
 	receipt, err := c.ether.GetTransactionReceipt(hash)
 	if err != nil {
-		return types.TransactionReceipt{}, err
+		return nil, err
 	}
 
 	return receipt, nil

--- a/namespace/core_namespace_test.go
+++ b/namespace/core_namespace_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/agiledragon/gomonkey"
+	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/poteto-go/go-alchemy-sdk/constant"
 	"github.com/poteto-go/go-alchemy-sdk/ether"
@@ -896,16 +897,16 @@ func TestCore_GetTransactionReceipt(t *testing.T) {
 		defer patches.Reset()
 
 		// Arrange
-		txHash := "hash"
-		expected := types.TransactionReceipt{
-			TransactionHash: txHash,
+		txHash := "0x0000000000000000000000000000000000000000000000000000000000000123"
+		expected := &gethTypes.Receipt{
+			TxHash: common.HexToHash(txHash),
 		}
 
 		// Mock & Assert
 		patches.ApplyMethod(
 			reflect.TypeOf(api),
 			"GetTransactionReceipt",
-			func(_ *ether.Ether, hash string) (types.TransactionReceipt, error) {
+			func(_ *ether.Ether, hash string) (*gethTypes.Receipt, error) {
 				assert.Equal(t, hash, txHash)
 				return expected, nil
 			},
@@ -915,7 +916,7 @@ func TestCore_GetTransactionReceipt(t *testing.T) {
 		actual, _ := core.GetTransactionReceipt(txHash)
 
 		// Assert
-		assert.Equal(t, expected, actual)
+		assert.Equal(t, txHash, actual.TxHash.Hex())
 	})
 
 	t.Run("if error occur in ether.TransactionReceipts & return internal error", func(t *testing.T) {
@@ -930,9 +931,9 @@ func TestCore_GetTransactionReceipt(t *testing.T) {
 		patches.ApplyMethod(
 			reflect.TypeOf(api),
 			"GetTransactionReceipt",
-			func(_ *ether.Ether, hash string) (types.TransactionReceipt, error) {
+			func(_ *ether.Ether, hash string) (*gethTypes.Receipt, error) {
 				assert.Equal(t, hash, txHash)
-				return types.TransactionReceipt{}, expectedErr
+				return nil, expectedErr
 			},
 		)
 

--- a/namespace/core_namespace_test.go
+++ b/namespace/core_namespace_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/poteto-go/go-alchemy-sdk/internal"
 	"github.com/poteto-go/go-alchemy-sdk/namespace"
 	"github.com/poteto-go/go-alchemy-sdk/types"
+	"github.com/poteto-go/go-alchemy-sdk/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -959,17 +960,32 @@ func TestCore_GetTransactionReceipts(t *testing.T) {
 		txArg := types.TransactionReceiptsArg{
 			BlockHash: txHash,
 		}
-		expected := []types.TransactionReceipt{
+		expectedAlchemyReceipt := []types.TransactionReceipt{
 			{
-				TransactionHash: txHash,
+				TransactionHash:   "0x504ce587a65bdbdb6414a0c6c16d86a04dd79bfcc4f2950eec9634b30ce5370f",
+				TransactionIndex:  "0x0",
+				BlockHash:         "0xe7212a92cfb9b06addc80dec2a0dfae9ea94fd344efeb157c41e12994fcad60a",
+				BlockNumber:       "0x50",
+				From:              "0x627306090abab3a6e1400e9345bc60c78a8bef57",
+				To:                "0xf17f52151ebef6c7334fad080c5704d77216b732",
+				CumulativeGasUsed: "0x5208",
+				GasUsed:           "0x5208",
+				Logs:              []types.LogResponse{},
+				LogsBloom:         "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+				EffectiveGasPrice: "0x1",
+				Type:              "0x0",
+				Status:            "0x1",
 			},
 		}
+
+		expected := make([]*gethTypes.Receipt, 1)
+		expected[0], _ = utils.TransformAlchemyReceiptToGeth(expectedAlchemyReceipt[0])
 
 		// Mock & Assert
 		patches.ApplyMethod(
 			reflect.TypeOf(api),
 			"GetTransactionReceipts",
-			func(_ *ether.Ether, arg types.TransactionReceiptsArg) ([]types.TransactionReceipt, error) {
+			func(_ *ether.Ether, arg types.TransactionReceiptsArg) ([]*gethTypes.Receipt, error) {
 				assert.Equal(t, arg, txArg)
 				return expected, nil
 			},
@@ -997,9 +1013,9 @@ func TestCore_GetTransactionReceipts(t *testing.T) {
 		patches.ApplyMethod(
 			reflect.TypeOf(api),
 			"GetTransactionReceipts",
-			func(_ *ether.Ether, arg types.TransactionReceiptsArg) ([]types.TransactionReceipt, error) {
+			func(_ *ether.Ether, arg types.TransactionReceiptsArg) ([]*gethTypes.Receipt, error) {
 				assert.Equal(t, arg, txArg)
-				return []types.TransactionReceipt{}, expectedErr
+				return []*gethTypes.Receipt{}, expectedErr
 			},
 		)
 

--- a/utils/hex.go
+++ b/utils/hex.go
@@ -26,6 +26,25 @@ func FromHex(hexString string) (int, error) {
 	return int(num), nil
 }
 
+func FromHexU64(hexString string) (uint64, error) {
+	if len(hexString) <= 1 {
+		return uint64(0), nil
+	}
+
+	if hexString[0:2] != "0x" {
+		return 0, constant.ErrInvalidHexString
+	}
+
+	// remove 0x
+	numString := hexString[2:]
+	num, err := strconv.ParseUint(numString, 16, 64)
+	if err != nil {
+		return 0, constant.ErrInvalidHexString
+	}
+
+	return num, nil
+}
+
 func FromBigHex(hexString string) (*big.Int, error) {
 	if len(hexString) <= 1 {
 		return big.NewInt(0), constant.ErrInvalidHexString

--- a/utils/hex_test.go
+++ b/utils/hex_test.go
@@ -20,16 +20,17 @@ func TestFromHex(t *testing.T) {
 		// Assert
 		assert.NoError(t, err)
 		assert.Equal(t, 1193046, result)
+
+		t.Run("empty string => 0", func(t *testing.T) {
+			// Act
+			res, _ := utils.FromHex("")
+
+			// Assert
+			assert.Equal(t, 0, res)
+		})
 	})
 
 	t.Run("error case:", func(t *testing.T) {
-		t.Run("empty string => constant.ErrInvalidHexString", func(t *testing.T) {
-			// Act
-			_, err := utils.FromHex("")
-
-			// Assert
-			assert.ErrorIs(t, err, constant.ErrInvalidHexString)
-		})
 
 		t.Run("invalid hex string => constant.ErrInvalidHexString", func(t *testing.T) {
 			// Act

--- a/utils/transformer.go
+++ b/utils/transformer.go
@@ -59,6 +59,7 @@ func TransformAlchemyReceiptToGeth(receipt types.TransactionReceipt) (*gethTypes
 	}
 
 	return &gethTypes.Receipt{
+		// nolint:gosec
 		Type:              uint8(typeU64),
 		PostState:         []byte(receipt.Root),
 		Status:            status,

--- a/utils/transformer.go
+++ b/utils/transformer.go
@@ -1,8 +1,11 @@
 package utils
 
 import (
+	"math"
+
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/poteto-go/go-alchemy-sdk/constant"
 	"github.com/poteto-go/go-alchemy-sdk/types"
 )
 
@@ -22,6 +25,10 @@ func TransformAlchemyReceiptToGeth(receipt types.TransactionReceipt) (*gethTypes
 	if err != nil {
 		return nil, err
 	}
+	if typeU64 > math.MaxUint8 {
+		return nil, constant.ErrOverFlow
+	}
+	typeU8 := uint8(typeU64)
 
 	status, err := FromHexU64(receipt.Status)
 	if err != nil {
@@ -53,14 +60,17 @@ func TransformAlchemyReceiptToGeth(receipt types.TransactionReceipt) (*gethTypes
 		return nil, err
 	}
 
-	txIndex, err := FromHexU64(receipt.TransactionIndex)
+	txIndexU64, err := FromHexU64(receipt.TransactionIndex)
 	if err != nil {
 		return nil, err
 	}
+	if txIndexU64 > math.MaxUint32 {
+		return nil, constant.ErrOverFlow
+	}
+	txIndex := uint(txIndexU64)
 
 	return &gethTypes.Receipt{
-		// nolint:gosec
-		Type:              uint8(typeU64),
+		Type:              typeU8,
 		PostState:         []byte(receipt.Root),
 		Status:            status,
 		CumulativeGasUsed: cGasUsed,
@@ -73,7 +83,7 @@ func TransformAlchemyReceiptToGeth(receipt types.TransactionReceipt) (*gethTypes
 		BlobGasUsed:       bGasUsed,
 		BlockHash:         common.HexToHash(receipt.BlockHash),
 		BlockNumber:       blockNumber,
-		TransactionIndex:  uint(txIndex),
+		TransactionIndex:  txIndex,
 	}, nil
 }
 
@@ -89,15 +99,23 @@ func TransformAlchemyLogToGeth(log types.LogResponse) (*gethTypes.Log, error) {
 		return nil, err
 	}
 
-	txIndex, err := FromHexU64(log.TransactionIndex)
+	txIndexU64, err := FromHexU64(log.TransactionIndex)
 	if err != nil {
 		return nil, err
 	}
+	if txIndexU64 > math.MaxUint32 {
+		return nil, constant.ErrOverFlow
+	}
+	txIndex := uint(txIndexU64)
 
-	logIndex, err := FromHexU64(log.LogIndex)
+	logIndexU64, err := FromHexU64(log.LogIndex)
 	if err != nil {
 		return nil, err
 	}
+	if logIndexU64 > math.MaxUint32 {
+		return nil, constant.ErrOverFlow
+	}
+	logIndex := uint(logIndexU64)
 
 	return &gethTypes.Log{
 		Address:     common.HexToAddress(log.Address),
@@ -105,9 +123,9 @@ func TransformAlchemyLogToGeth(log types.LogResponse) (*gethTypes.Log, error) {
 		Data:        []byte(log.Data),
 		BlockNumber: blockNumber,
 		TxHash:      common.HexToHash(log.TransactionHash),
-		TxIndex:     uint(txIndex),
+		TxIndex:     txIndex,
 		BlockHash:   common.HexToHash(log.BlockHash),
-		Index:       uint(logIndex),
+		Index:       logIndex,
 		Removed:     log.Removed,
 	}, nil
 }

--- a/utils/transformer.go
+++ b/utils/transformer.go
@@ -1,0 +1,112 @@
+package utils
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/poteto-go/go-alchemy-sdk/types"
+)
+
+// from alchemy.Receipt -> geth.Receipt
+func TransformAlchemyReceiptToGeth(receipt types.TransactionReceipt) (*gethTypes.Receipt, error) {
+	logs := make([]*gethTypes.Log, len(receipt.Logs))
+	for i, log := range receipt.Logs {
+		gethLog, err := TransformAlchemyLogToGeth(log)
+		if err != nil {
+			return nil, err
+		}
+
+		logs[i] = gethLog
+	}
+
+	typeU64, err := FromHexU64(receipt.Type)
+	if err != nil {
+		return nil, err
+	}
+
+	status, err := FromHexU64(receipt.Status)
+	if err != nil {
+		return nil, err
+	}
+
+	cGasUsed, err := FromHexU64(receipt.CumulativeGasUsed)
+	if err != nil {
+		return nil, err
+	}
+
+	gasUsed, err := FromHexU64(receipt.GasUsed)
+	if err != nil {
+		return nil, err
+	}
+
+	eGasPrice, err := FromBigHex(receipt.EffectiveGasPrice)
+	if err != nil {
+		return nil, err
+	}
+
+	bGasUsed, err := FromHexU64(receipt.BlobGasUsed)
+	if err != nil {
+		return nil, err
+	}
+
+	blockNumber, err := FromBigHex(receipt.BlockNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	txIndex, err := FromHexU64(receipt.TransactionIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gethTypes.Receipt{
+		Type:              uint8(typeU64),
+		PostState:         []byte(receipt.Root),
+		Status:            status,
+		CumulativeGasUsed: cGasUsed,
+		Bloom:             gethTypes.Bloom([]byte(receipt.LogsBloom)),
+		Logs:              logs,
+		TxHash:            common.HexToHash(receipt.TransactionHash),
+		ContractAddress:   common.HexToAddress(receipt.ContractAddress),
+		GasUsed:           gasUsed,
+		EffectiveGasPrice: eGasPrice,
+		BlobGasUsed:       bGasUsed,
+		BlockHash:         common.HexToHash(receipt.BlockHash),
+		BlockNumber:       blockNumber,
+		TransactionIndex:  uint(txIndex),
+	}, nil
+}
+
+// transform alchemy.LogResponse -> geth.Log
+func TransformAlchemyLogToGeth(log types.LogResponse) (*gethTypes.Log, error) {
+	topics := make([]common.Hash, len(log.Topics))
+	for i, topic := range log.Topics {
+		topics[i] = common.HexToHash(topic)
+	}
+
+	blockNumber, err := FromHexU64(log.BlockNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	txIndex, err := FromHexU64(log.TransactionIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	logIndex, err := FromHexU64(log.LogIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gethTypes.Log{
+		Address:     common.HexToAddress(log.Address),
+		Topics:      topics,
+		Data:        []byte(log.Data),
+		BlockNumber: blockNumber,
+		TxHash:      common.HexToHash(log.TransactionHash),
+		TxIndex:     uint(txIndex),
+		BlockHash:   common.HexToHash(log.BlockHash),
+		Index:       uint(logIndex),
+		Removed:     log.Removed,
+	}, nil
+}

--- a/utils/transformer_test.go
+++ b/utils/transformer_test.go
@@ -1,0 +1,321 @@
+package utils_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/poteto-go/go-alchemy-sdk/types"
+	"github.com/poteto-go/go-alchemy-sdk/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransformAlchemyReceiptToGeth(t *testing.T) {
+	validLogs := []types.LogResponse{
+		{
+			Address: "0x1",
+			Topics: []string{
+				"0x2",
+				"0x3",
+			},
+			Data:             "0x1",
+			BlockNumber:      "0x1",
+			TransactionHash:  "0x1",
+			BlockHash:        "0x1",
+			TransactionIndex: "0x1",
+			LogIndex:         "0x1",
+			Removed:          false,
+		},
+	}
+	t.Run("transform alchemy.TransactionReceipt -> geth.Receipt", func(t *testing.T) {
+		// Arrange
+		receipt := types.TransactionReceipt{
+			TransactionHash:   "0x504ce587a65bdbdb6414a0c6c16d86a04dd79bfcc4f2950eec9634b30ce5370f",
+			TransactionIndex:  "0x0",
+			BlockHash:         "0xe7212a92cfb9b06addc80dec2a0dfae9ea94fd344efeb157c41e12994fcad60a",
+			BlockNumber:       "0x50",
+			From:              "0x627306090abab3a6e1400e9345bc60c78a8bef57",
+			To:                "0xf17f52151ebef6c7334fad080c5704d77216b732",
+			ContractAddress:   "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
+			CumulativeGasUsed: "0x1458",
+			GasUsed:           "0x1458",
+			BlobGasUsed:       "0x1458",
+			Logs:              validLogs,
+			LogsBloom:         "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+			EffectiveGasPrice: "0x1",
+			Type:              "0x0",
+			Status:            "0x1",
+		}
+
+		// Act
+		gethReceipt, err := utils.TransformAlchemyReceiptToGeth(receipt)
+
+		// Assert
+		assert.Nil(t, err)
+		assert.Equal(t, gethReceipt.Type, uint8(0))
+		assert.Equal(t, gethReceipt.Status, uint64(1))
+		assert.Equal(t, gethReceipt.CumulativeGasUsed, uint64(5208))
+		assert.Equal(t, gethReceipt.GasUsed, uint64(5208))
+		assert.Equal(t, gethReceipt.EffectiveGasPrice.Cmp(big.NewInt(1)), 0)
+		assert.Equal(t, gethReceipt.BlobGasUsed, uint64(5208))
+		assert.Equal(t, gethReceipt.BlockNumber.Cmp(big.NewInt(80)), 0)
+		assert.Equal(t, gethReceipt.TransactionIndex, uint(0))
+		assert.Equal(t, gethReceipt.BlockHash.Hex(), receipt.BlockHash)
+		assert.Equal(t, gethReceipt.TxHash.Hex(), receipt.TransactionHash)
+		assert.Equal(t, gethReceipt.ContractAddress.Hex(), receipt.ContractAddress)
+		assert.Equal(t, len(gethReceipt.Logs), 1)
+	})
+
+	t.Run("error case", func(t *testing.T) {
+		t.Run("if logs is invalid", func(t *testing.T) {
+			// Arrange
+			receipt := types.TransactionReceipt{
+				Logs: []types.LogResponse{
+					{
+						Address: "address",
+					},
+				},
+			}
+
+			// Act
+			_, err := utils.TransformAlchemyReceiptToGeth(receipt)
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if type is invalid", func(t *testing.T) {
+			// Arrange
+			receipt := types.TransactionReceipt{
+				Type: "hello",
+				Logs: validLogs,
+			}
+
+			// Act
+			_, err := utils.TransformAlchemyReceiptToGeth(receipt)
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if status is invalid", func(t *testing.T) {
+			// Arrange
+			receipt := types.TransactionReceipt{
+				Status: "hello",
+				Logs:   validLogs,
+				Type:   "0x1",
+			}
+
+			// Act
+			_, err := utils.TransformAlchemyReceiptToGeth(receipt)
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if invalid cumulativeGasUsed", func(t *testing.T) {
+			// Arrange
+			receipt := types.TransactionReceipt{
+				Status:            "0x1",
+				Logs:              validLogs,
+				Type:              "0x1",
+				CumulativeGasUsed: "hello",
+			}
+
+			// Act
+			_, err := utils.TransformAlchemyReceiptToGeth(receipt)
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if invalid GasUsed", func(t *testing.T) {
+			// Arrange
+			receipt := types.TransactionReceipt{
+				Status:            "0x1",
+				Logs:              validLogs,
+				Type:              "0x1",
+				CumulativeGasUsed: "0x1",
+				GasUsed:           "hello",
+			}
+
+			// Act
+			_, err := utils.TransformAlchemyReceiptToGeth(receipt)
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if invalid EffectiveGasUsed", func(t *testing.T) {
+			// Arrange
+			receipt := types.TransactionReceipt{
+				Status:            "0x1",
+				Logs:              validLogs,
+				Type:              "0x1",
+				CumulativeGasUsed: "0x1",
+				GasUsed:           "0x1",
+				EffectiveGasPrice: "hello",
+			}
+
+			// Act
+			_, err := utils.TransformAlchemyReceiptToGeth(receipt)
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if invalid BlobGasUsed", func(t *testing.T) {
+			// Arrange
+			receipt := types.TransactionReceipt{
+				Status:            "0x1",
+				Logs:              validLogs,
+				Type:              "0x1",
+				CumulativeGasUsed: "0x1",
+				GasUsed:           "0x1",
+				EffectiveGasPrice: "0x1",
+				BlobGasUsed:       "hello",
+			}
+
+			// Act
+			_, err := utils.TransformAlchemyReceiptToGeth(receipt)
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if invalid BlockNumber", func(t *testing.T) {
+			// Arrange
+			receipt := types.TransactionReceipt{
+				Status:            "0x1",
+				Logs:              validLogs,
+				Type:              "0x1",
+				CumulativeGasUsed: "0x1",
+				GasUsed:           "0x1",
+				EffectiveGasPrice: "0x1",
+				BlobGasUsed:       "0x1",
+				BlockNumber:       "hello",
+			}
+
+			// Act
+			_, err := utils.TransformAlchemyReceiptToGeth(receipt)
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if invalid TransactionIndex", func(t *testing.T) {
+			// Arrange
+			receipt := types.TransactionReceipt{
+				Status:            "0x1",
+				Logs:              validLogs,
+				Type:              "0x1",
+				CumulativeGasUsed: "0x1",
+				GasUsed:           "0x1",
+				EffectiveGasPrice: "0x1",
+				BlobGasUsed:       "0x1",
+				BlockNumber:       "0x1",
+				TransactionIndex:  "hello",
+			}
+
+			// Act
+			_, err := utils.TransformAlchemyReceiptToGeth(receipt)
+
+			// Assert
+			assert.Error(t, err)
+		})
+	})
+}
+
+func TestTransformAlchemyLogToGeth(t *testing.T) {
+	t.Run("transform alchemy.LogResponse -> geth.Log", func(t *testing.T) {
+		// Arrange
+		address := "0x0000000000000001111111111111111111111111"
+		topic1 := "0x0000000000000000000000000000000000000000000000000000000000000001"
+		topic2 := "0x0000000000000000000000000000000000000000000000000000000000000002"
+		data := "0x0000000000000000000000000000000000000000000000000000000000000003"
+		blockNumber := "0x1"
+		blockHash := "0x0000000000000000000000000000000000000000000000000000000000000001"
+		transactionHash := "0x0000000000000000000000000000000000000000000000000000000000000002"
+		transactionIndex := "0x0000000000000000000000000000000000000000000000000000000000000002"
+		logIndex := "0x0000000000000000000000000000000000000000000000000000000000000003"
+
+		LogResponse := types.LogResponse{
+			Address: address,
+			Topics: []string{
+				topic1,
+				topic2,
+			},
+			Data:             data,
+			BlockNumber:      blockNumber,
+			BlockHash:        blockHash,
+			TransactionHash:  transactionHash,
+			TransactionIndex: transactionIndex,
+			LogIndex:         logIndex,
+			Removed:          false,
+		}
+
+		// Act
+		log, err := utils.TransformAlchemyLogToGeth(LogResponse)
+
+		// Assert
+		assert.Nil(t, err)
+		assert.Equal(t, log.Address.Hex(), address)
+		assert.Equal(t, log.Topics[0].Hex(), topic1)
+		assert.Equal(t, log.Topics[1].Hex(), topic2)
+		assert.Equal(t, string(log.Data), data)
+		assert.Equal(t, log.BlockNumber, uint64(1))
+		assert.Equal(t, log.TxHash.Hex(), transactionHash)
+		assert.Equal(t, log.TxIndex, uint(2))
+		assert.Equal(t, log.BlockHash.Hex(), blockHash)
+		assert.Equal(t, log.Index, uint(3))
+		assert.Equal(t, log.Removed, false)
+	})
+
+	t.Run("error case", func(t *testing.T) {
+		t.Run("if blockNumber is invalid", func(t *testing.T) {
+			// Arrange
+			blockNumber := "hello"
+			logResponse := types.LogResponse{
+				BlockNumber: blockNumber,
+			}
+
+			// Act
+			_, err := utils.TransformAlchemyLogToGeth(logResponse)
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if txIndex is invalid", func(t *testing.T) {
+			// Arrange
+			blockNumber := "0x123"
+			txIndex := "hello"
+			logResponse := types.LogResponse{
+				BlockNumber:      blockNumber,
+				TransactionIndex: txIndex,
+			}
+
+			// Act
+			_, err := utils.TransformAlchemyLogToGeth(logResponse)
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if logIndex is invalid", func(t *testing.T) {
+			// Arrange
+			blockNumber := "0x123"
+			txIndex := "0x123"
+			logIndex := "hello"
+
+			// Act
+			_, err := utils.TransformAlchemyLogToGeth(types.LogResponse{
+				BlockNumber:      blockNumber,
+				TransactionIndex: txIndex,
+				LogIndex:         logIndex,
+			})
+
+			// Assert
+			assert.Error(t, err)
+		})
+	})
+}


### PR DESCRIPTION
### Changes
- fix: geth migration `Core.GetTransactionReceipt`
- fix: `Core.GetTransactionReceipts` return `*geth.Receipt` array