### PR TITLE
`internal` namespaceから設定を切り出す

### DIFF
--- a/ether/ether_config.go
+++ b/ether/ether_config.go
@@ -3,7 +3,7 @@ package ether
 import (
 	"time"
 
-	"github.com/poteto-go/go-alchemy-sdk/internal"
+	"github.com/poteto-go/go-alchemy-sdk/types"
 )
 
 // cf. gsk.AlchemyConfig
@@ -12,10 +12,10 @@ type EtherApiConfig struct {
 	url            string
 	maxRetries     int
 	requestTimeout time.Duration
-	backoffConfig  *internal.BackoffConfig
+	backoffConfig  *types.BackoffConfig
 }
 
-func NewEtherApiConfig(url string, maxRetries int, requestTimeout time.Duration, backoffConfig *internal.BackoffConfig) EtherApiConfig {
+func NewEtherApiConfig(url string, maxRetries int, requestTimeout time.Duration, backoffConfig *types.BackoffConfig) EtherApiConfig {
 	return EtherApiConfig{
 		url:            url,
 		maxRetries:     maxRetries,

--- a/ether/ether_config_test.go
+++ b/ether/ether_config_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/poteto-go/go-alchemy-sdk/internal"
+	"github.com/poteto-go/go-alchemy-sdk/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,7 +13,7 @@ func TestNewEtherApiConfig(t *testing.T) {
 	url := "url"
 	maxRetries := 1
 	requestTimeout := time.Duration(1)
-	backoffConfig := internal.BackoffConfig{
+	backoffConfig := types.BackoffConfig{
 		MaxRetries: 1,
 	}
 

--- a/ether/ether_core_test.go
+++ b/ether/ether_core_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/poteto-go/go-alchemy-sdk/ether"
 	eth "github.com/poteto-go/go-alchemy-sdk/ether"
 	"github.com/poteto-go/go-alchemy-sdk/gas"
-	"github.com/poteto-go/go-alchemy-sdk/internal"
 	"github.com/poteto-go/go-alchemy-sdk/types"
 	"github.com/poteto-go/go-alchemy-sdk/utils"
 	"github.com/stretchr/testify/assert"
@@ -57,7 +56,7 @@ func newProviderForTest() *gas.AlchemyProvider {
 		gas.AlchemySetting{
 			ApiKey:  "hoge",
 			Network: "fuga",
-			BackoffConfig: &internal.BackoffConfig{
+			BackoffConfig: &types.BackoffConfig{
 				MaxRetries: 0,
 			},
 		},

--- a/gas/alchemy_config.go
+++ b/gas/alchemy_config.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/poteto-go/go-alchemy-sdk/ether"
-	"github.com/poteto-go/go-alchemy-sdk/internal"
 	"github.com/poteto-go/go-alchemy-sdk/types"
 )
 
@@ -15,7 +14,7 @@ type AlchemyConfig struct {
 	maxRetries     int
 	requestTimeout time.Duration
 	isRequestBatch bool
-	backoffConfig  *internal.BackoffConfig
+	backoffConfig  *types.BackoffConfig
 }
 
 func NewAlchemyConfig(setting AlchemySetting) AlchemyConfig {
@@ -34,7 +33,7 @@ func NewAlchemyConfig(setting AlchemySetting) AlchemyConfig {
 	}
 
 	if setting.BackoffConfig == nil {
-		config.backoffConfig = &internal.DefaultBackoffConfig
+		config.backoffConfig = &types.DefaultBackoffConfig
 	}
 
 	return config

--- a/gas/alchemy_setting.go
+++ b/gas/alchemy_setting.go
@@ -3,15 +3,14 @@ package gas
 import (
 	"time"
 
-	"github.com/poteto-go/go-alchemy-sdk/internal"
 	"github.com/poteto-go/go-alchemy-sdk/types"
 )
 
 type AlchemySetting struct {
-	ApiKey         string                  `yaml:"api_key"`
-	Network        types.Network           `yaml:"network"`
-	MaxRetries     int                     `yaml:"max_retries"`
-	IsRequestBatch bool                    `yaml:"is_request_batch"`
-	BackoffConfig  *internal.BackoffConfig `yaml:"backoff_config"`
-	RequestTimeout time.Duration           `yaml:"request_timeout"`
+	ApiKey         string                `yaml:"api_key"`
+	Network        types.Network         `yaml:"network"`
+	MaxRetries     int                   `yaml:"max_retries"`
+	IsRequestBatch bool                  `yaml:"is_request_batch"`
+	BackoffConfig  *types.BackoffConfig  `yaml:"backoff_config"`
+	RequestTimeout time.Duration         `yaml:"request_timeout"`
 }

--- a/internal/backoff.go
+++ b/internal/backoff.go
@@ -6,31 +6,18 @@ import (
 	"time"
 
 	"github.com/poteto-go/go-alchemy-sdk/constant"
+	"github.com/poteto-go/go-alchemy-sdk/types"
 	"github.com/poteto-go/go-alchemy-sdk/utils"
 )
 
-type BackoffConfig struct {
-	Mode           string  `yaml:"mode"`
-	MaxRetries     int     `yaml:"max_retries"`
-	InitialDelayMs float64 `yaml:"initial_delay_ms"`
-	MaxDelayMs     float64 `yaml:"max_delay_ms"`
-}
-
-var DefaultBackoffConfig = BackoffConfig{
-	Mode:           "exponential",
-	MaxRetries:     1,
-	InitialDelayMs: 1000,
-	MaxDelayMs:     30000,
-}
-
 type BackoffManager struct {
-	config    BackoffConfig
+	config    types.BackoffConfig
 	retries   int
 	lastDelay float64
 	lock      sync.Mutex
 }
 
-func NewBackoffManager(config BackoffConfig) *BackoffManager {
+func NewBackoffManager(config types.BackoffConfig) *BackoffManager {
 	return &BackoffManager{
 		config:    config,
 		retries:   0,

--- a/internal/backoff_test.go
+++ b/internal/backoff_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 
 	"github.com/poteto-go/go-alchemy-sdk/constant"
+	"github.com/poteto-go/go-alchemy-sdk/types"
 	"github.com/stretchr/testify/assert"
 )
 
-var backoffConfigTest = BackoffConfig{
+var backoffConfigTest = types.BackoffConfig{
 	Mode:           "exponential",
 	MaxRetries:     3,
 	InitialDelayMs: 10,
@@ -16,7 +17,7 @@ var backoffConfigTest = BackoffConfig{
 
 func TestNewBackoffManager(t *testing.T) {
 	// Arrange
-	config := BackoffConfig{
+	config := types.BackoffConfig{
 		Mode:           "exponential",
 		MaxRetries:     1,
 		InitialDelayMs: 10,

--- a/internal/dispatch.go
+++ b/internal/dispatch.go
@@ -8,7 +8,7 @@ import (
 )
 
 func requestWithBackoffError(
-	backoffConfig BackoffConfig,
+	backoffConfig types.BackoffConfig,
 	operation func() error,
 ) error {
 	var lastHttpError error
@@ -27,7 +27,7 @@ func requestWithBackoffError(
 }
 
 func requestWithBackoff[T any](
-	backoffConfig BackoffConfig,
+	backoffConfig types.BackoffConfig,
 	operation func() (T, error),
 ) (T, error) {
 	var lastHttpError error
@@ -47,7 +47,7 @@ func requestWithBackoff[T any](
 }
 
 func requestWithBackoffTuple[T any, O any](
-	backoffConfig BackoffConfig,
+	backoffConfig types.BackoffConfig,
 	operation func() (T, O, error),
 ) (T, O, error) {
 	var lastHttpError error
@@ -68,7 +68,7 @@ func requestWithBackoffTuple[T any, O any](
 }
 
 func RequestHttpWithBackoff(
-	backoffConfig BackoffConfig,
+	backoffConfig types.BackoffConfig,
 	requestConfig types.RequestConfig,
 	handler types.AlchemyFetchHandler,
 	request types.AlchemyRequest,
@@ -81,7 +81,7 @@ func RequestHttpWithBackoff(
 }
 
 func GethRequestArgWithBackOff[T any, A any](
-	backoffConfig *BackoffConfig,
+	backoffConfig *types.BackoffConfig,
 	timeout time.Duration,
 	handler func(
 		context.Context, A,
@@ -89,7 +89,7 @@ func GethRequestArgWithBackOff[T any, A any](
 	arg A,
 ) (T, error) {
 	if backoffConfig == nil {
-		backoffConfig = &DefaultBackoffConfig
+		backoffConfig = &types.DefaultBackoffConfig
 	}
 	operation := func() (T, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -100,7 +100,7 @@ func GethRequestArgWithBackOff[T any, A any](
 }
 
 func GethRequestTwoArgWithBackOff[T any, A any, B any](
-	backoffConfig *BackoffConfig,
+	backoffConfig *types.BackoffConfig,
 	timeout time.Duration,
 	handler func(
 		context.Context, A, B,
@@ -109,7 +109,7 @@ func GethRequestTwoArgWithBackOff[T any, A any, B any](
 	arg2 B,
 ) (T, error) {
 	if backoffConfig == nil {
-		backoffConfig = &DefaultBackoffConfig
+		backoffConfig = &types.DefaultBackoffConfig
 	}
 	operation := func() (T, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -120,7 +120,7 @@ func GethRequestTwoArgWithBackOff[T any, A any, B any](
 }
 
 func GethRequestThreeArgWithBackOff[T any, A any, B any, C any](
-	backoffConfig *BackoffConfig,
+	backoffConfig *types.BackoffConfig,
 	timeout time.Duration,
 	handler func(
 		context.Context, A, B, C,
@@ -130,7 +130,7 @@ func GethRequestThreeArgWithBackOff[T any, A any, B any, C any](
 	arg3 C,
 ) (T, error) {
 	if backoffConfig == nil {
-		backoffConfig = &DefaultBackoffConfig
+		backoffConfig = &types.DefaultBackoffConfig
 	}
 	operation := func() (T, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -141,7 +141,7 @@ func GethRequestThreeArgWithBackOff[T any, A any, B any, C any](
 }
 
 func GethRequestArgWithBackOffTuple[T any, A any, O any](
-	backoffConfig *BackoffConfig,
+	backoffConfig *types.BackoffConfig,
 	timeout time.Duration,
 	handler func(
 		context.Context, A,
@@ -149,7 +149,7 @@ func GethRequestArgWithBackOffTuple[T any, A any, O any](
 	arg A,
 ) (T, O, error) {
 	if backoffConfig == nil {
-		backoffConfig = &DefaultBackoffConfig
+		backoffConfig = &types.DefaultBackoffConfig
 	}
 	operation := func() (T, O, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -160,14 +160,14 @@ func GethRequestArgWithBackOffTuple[T any, A any, O any](
 }
 
 func GethRequestWithBackOff[T any](
-	backoffConfig *BackoffConfig,
+	backoffConfig *types.BackoffConfig,
 	timeout time.Duration,
 	handler func(
 		context.Context,
 	) (T, error),
 ) (T, error) {
 	if backoffConfig == nil {
-		backoffConfig = &DefaultBackoffConfig
+		backoffConfig = &types.DefaultBackoffConfig
 	}
 	operation := func() (T, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -178,7 +178,7 @@ func GethRequestWithBackOff[T any](
 }
 
 func GethRequestSingleErrorWithBackOff[A any](
-	backoffConfig *BackoffConfig,
+	backoffConfig *types.BackoffConfig,
 	timeout time.Duration,
 	handler func(
 		context.Context, A,
@@ -186,7 +186,7 @@ func GethRequestSingleErrorWithBackOff[A any](
 	arg A,
 ) error {
 	if backoffConfig == nil {
-		backoffConfig = &DefaultBackoffConfig
+		backoffConfig = &types.DefaultBackoffConfig
 	}
 	operation := func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/internal/dispatch_test.go
+++ b/internal/dispatch_test.go
@@ -18,7 +18,7 @@ func TestRequestWithBackoff(t *testing.T) {
 		}
 
 		// Act
-		result, err := requestWithBackoff(DefaultBackoffConfig, operation)
+		result, err := requestWithBackoff(types.DefaultBackoffConfig, operation)
 
 		// Assert
 		assert.NoError(t, err)
@@ -35,7 +35,7 @@ func TestRequestWithBackoff(t *testing.T) {
 			}
 			return 1, nil
 		}
-		config := BackoffConfig{
+		config := types.BackoffConfig{
 			MaxRetries: 3,
 		}
 
@@ -53,7 +53,7 @@ func TestRequestWithBackoff(t *testing.T) {
 		operation := func() (int, error) {
 			return 0, errors.New("test error")
 		}
-		config := BackoffConfig{
+		config := types.BackoffConfig{
 			MaxRetries: 3,
 		}
 
@@ -73,7 +73,7 @@ func TestRequestWithBackoffTuple(t *testing.T) {
 		}
 
 		// Act
-		result1, result2, err := requestWithBackoffTuple(DefaultBackoffConfig, operation)
+		result1, result2, err := requestWithBackoffTuple(types.DefaultBackoffConfig, operation)
 
 		// Assert
 		assert.NoError(t, err)
@@ -91,7 +91,7 @@ func TestRequestWithBackoffTuple(t *testing.T) {
 			}
 			return 1, 2, nil
 		}
-		config := BackoffConfig{
+		config := types.BackoffConfig{
 			MaxRetries: 3,
 		}
 
@@ -110,7 +110,7 @@ func TestRequestWithBackoffTuple(t *testing.T) {
 		operation := func() (int, int, error) {
 			return 0, 0, errors.New("test error")
 		}
-		config := BackoffConfig{
+		config := types.BackoffConfig{
 			MaxRetries: 3,
 		}
 
@@ -125,7 +125,7 @@ func TestRequestWithBackoffTuple(t *testing.T) {
 func TestRequestHttpWithBackoff(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		// Arrange
-		backoffConfig := BackoffConfig{
+		backoffConfig := types.BackoffConfig{
 			MaxRetries: 1,
 		}
 		requestConfig := types.RequestConfig{}
@@ -147,7 +147,7 @@ func TestRequestHttpWithBackoff(t *testing.T) {
 func TestGethRequestArgWithBackOff(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		// Arrange
-		backoffConfig := &BackoffConfig{
+		backoffConfig := &types.BackoffConfig{
 			MaxRetries: 1,
 		}
 		mockHandler := func(ctx context.Context, a int) (int, error) {
@@ -180,7 +180,7 @@ func TestGethRequestArgWithBackOff(t *testing.T) {
 func TestGethRequestTwoArgWithBackOff(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		// Arrange
-		backoffConfig := &BackoffConfig{
+		backoffConfig := &types.BackoffConfig{
 			MaxRetries: 1,
 		}
 		mockHandler := func(ctx context.Context, a, b int) (int, error) {
@@ -213,7 +213,7 @@ func TestGethRequestTwoArgWithBackOff(t *testing.T) {
 func TestGethRequestThreeArgWithBackOff(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		// Arrange
-		backoffConfig := &BackoffConfig{
+		backoffConfig := &types.BackoffConfig{
 			MaxRetries: 1,
 		}
 		mockHandler := func(ctx context.Context, a, b, c int) (int, error) {
@@ -246,7 +246,7 @@ func TestGethRequestThreeArgWithBackOff(t *testing.T) {
 func TestGethRequestArgWithBackOffTuple(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		// Arrange
-		backoffConfig := &BackoffConfig{
+		backoffConfig := &types.BackoffConfig{
 			MaxRetries: 1,
 		}
 		mockHandler := func(ctx context.Context, a int) (int, int, error) {
@@ -281,7 +281,7 @@ func TestGethRequestArgWithBackOffTuple(t *testing.T) {
 func TestGethRequestWithBackOff(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		// Arrange
-		backoffConfig := &BackoffConfig{
+		backoffConfig := &types.BackoffConfig{
 			MaxRetries: 1,
 		}
 		mockHandler := func(ctx context.Context) (int, error) {
@@ -314,7 +314,7 @@ func TestGethRequestWithBackOff(t *testing.T) {
 func TestGethRequestSingleErrorWithBackOff(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		// Arrange
-		backoffConfig := &BackoffConfig{
+		backoffConfig := &types.BackoffConfig{
 			MaxRetries: 1,
 		}
 		mockHandler := func(ctx context.Context, a int) error {
@@ -331,7 +331,7 @@ func TestGethRequestSingleErrorWithBackOff(t *testing.T) {
 	t.Run("backoff", func(t *testing.T) {
 		// Arrange
 		callCount := 0
-		backoffConfig := &BackoffConfig{
+		backoffConfig := &types.BackoffConfig{
 			MaxRetries: 3,
 		}
 		mockHandler := func(ctx context.Context, a int) error {
@@ -352,7 +352,7 @@ func TestGethRequestSingleErrorWithBackOff(t *testing.T) {
 
 	t.Run("max retries exceeded", func(t *testing.T) {
 		// Arrange
-		backoffConfig := &BackoffConfig{
+		backoffConfig := &types.BackoffConfig{
 			MaxRetries: 3,
 		}
 		mockHandler := func(ctx context.Context, a int) error {
@@ -388,7 +388,7 @@ func TestRequestWithBackoffError(t *testing.T) {
 		}
 
 		// Act
-		err := requestWithBackoffError(DefaultBackoffConfig, operation)
+		err := requestWithBackoffError(types.DefaultBackoffConfig, operation)
 
 		// Assert
 		assert.NoError(t, err)
@@ -404,7 +404,7 @@ func TestRequestWithBackoffError(t *testing.T) {
 			}
 			return nil
 		}
-		config := BackoffConfig{
+		config := types.BackoffConfig{
 			MaxRetries: 3,
 		}
 
@@ -421,7 +421,7 @@ func TestRequestWithBackoffError(t *testing.T) {
 		operation := func() error {
 			return errors.New("test error")
 		}
-		config := BackoffConfig{
+		config := types.BackoffConfig{
 			MaxRetries: 3,
 		}
 

--- a/namespace/core_namespace_test.go
+++ b/namespace/core_namespace_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/poteto-go/go-alchemy-sdk/constant"
 	"github.com/poteto-go/go-alchemy-sdk/ether"
 	"github.com/poteto-go/go-alchemy-sdk/gas"
-	"github.com/poteto-go/go-alchemy-sdk/internal"
 	"github.com/poteto-go/go-alchemy-sdk/namespace"
 	"github.com/poteto-go/go-alchemy-sdk/types"
 	"github.com/poteto-go/go-alchemy-sdk/utils"
@@ -24,7 +23,7 @@ func newEtherApi() *ether.Ether {
 	setting := gas.AlchemySetting{
 		ApiKey:  "hoge",
 		Network: "fuga",
-		BackoffConfig: &internal.BackoffConfig{
+		BackoffConfig: &types.BackoffConfig{
 			MaxRetries: 0,
 		},
 	}

--- a/types/backoff.go
+++ b/types/backoff.go
@@ -1,0 +1,15 @@
+package types
+
+type BackoffConfig struct {
+	Mode           string  `yaml:"mode"`
+	MaxRetries     int     `yaml:"max_retries"`
+	InitialDelayMs float64 `yaml:"initial_delay_ms"`
+	MaxDelayMs     float64 `yaml:"max_delay_ms"`
+}
+
+var DefaultBackoffConfig = BackoffConfig{
+	Mode:           "exponential",
+	MaxRetries:     1,
+	InitialDelayMs: 1000,
+	MaxDelayMs:     30000,
+}


### PR DESCRIPTION
### Changes
- fix: `internal` namespaceから設定を切り出す