### PR TITLE
:bug: Fix JWT expiry window using wrong time unit

### DIFF
--- a/ether/ether.go
+++ b/ether/ether.go
@@ -76,7 +76,7 @@ func (ether *Ether) isClientJwsAlive() bool {
 	}
 
 	now := time.Now().Unix()
-	return ether.clientCreatedAt+(time.Second.Microseconds()*60) >= now
+	return ether.clientCreatedAt+60 >= now
 }
 
 // kill all client

--- a/ether/ether_secret_test.go
+++ b/ether/ether_secret_test.go
@@ -140,6 +140,40 @@ func TestEther_RecreateExpiredJws(t *testing.T) {
 	})
 }
 
+func TestEther_JwtExpiry_60SecondWindow(t *testing.T) {
+	t.Run("within 59 seconds: same client is reused", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			e := newEtherApiWSecretForTest()
+			err := e.SetEthClient()
+			assert.NoError(t, err)
+			firstClient := e.Client()
+
+			time.Sleep(59 * time.Second)
+
+			err = e.SetEthClient()
+			assert.NoError(t, err)
+
+			assert.Same(t, firstClient, e.Client())
+		})
+	})
+
+	t.Run("after 61 seconds: client is recreated with fresh JWT", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			e := newEtherApiWSecretForTest()
+			err := e.SetEthClient()
+			assert.NoError(t, err)
+			firstClient := e.Client()
+
+			time.Sleep(61 * time.Second)
+
+			err = e.SetEthClient()
+			assert.NoError(t, err)
+
+			assert.NotSame(t, firstClient, e.Client())
+		})
+	})
+}
+
 func TestEther_InvalidJwtSecret(t *testing.T) {
 	t.Run("success request", func(t *testing.T) {
 		// Arrange


### PR DESCRIPTION
## Summary

- `isClientJwsAlive()` compared `time.Now().Unix()` (seconds) against a threshold built with `time.Second.Microseconds()*60` (= 60,000,000 µs ≈ 1.9 years), so the client was never considered stale and the JWT was never rotated after the real 60-second geth window.
- Fixed by replacing the threshold with the plain integer `60` — both sides are now Unix seconds and the window is the intended 60 seconds.
- Added `TestEther_JwtExpiry_60SecondWindow` with two `synctest`-based sub-tests:  one verifying the client is reused within 59 s, and one verifying it is recreated after 61 s.

## Test plan

- [x] `TestEther_JwtExpiry_60SecondWindow/within_59_seconds:_same_client_is_reused` — PASS
- [x] `TestEther_JwtExpiry_60SecondWindow/after_61_seconds:_client_is_recreated_with_fresh_JWT` — PASS (was FAIL before fix)
- [x] All existing `ether` package tests still pass

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)