### PR TITLE
:bug: Fix CodeAt/CodeAtHash hex prefix and IsContractAddress test (closes #325, #318)

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -128,7 +128,7 @@ func TestSenario_DeployContract(t *testing.T) {
 			})
 
 			assert.Nil(t, err)
-			assert.Equal(t, code[:8], artifacts.PotetoStorageMetaData.Bin[2:10])
+			assert.Equal(t, code[2:10], artifacts.PotetoStorageMetaData.Bin[2:10])
 
 			block, err := alchemy.Core.GetBlock(types.BlockTagOrHash{
 				BlockTag: "latest",
@@ -142,7 +142,7 @@ func TestSenario_DeployContract(t *testing.T) {
 			})
 
 			assert.Nil(t, err)
-			assert.Equal(t, code[:8], artifacts.PotetoStorageMetaData.Bin[2:10])
+			assert.Equal(t, code[2:10], artifacts.PotetoStorageMetaData.Bin[2:10])
 
 			t.Run("can get transaction & its receipt form deployed block", func(t *testing.T) {
 				txHash := block.Body().Transactions[0].Hash()

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -128,7 +128,7 @@ func TestSenario_DeployContract(t *testing.T) {
 			})
 
 			assert.Nil(t, err)
-			assert.Equal(t, code[2:10], artifacts.PotetoStorageMetaData.Bin[2:10])
+			assert.Equal(t, code[:10], artifacts.PotetoStorageMetaData.Bin[:10])
 
 			block, err := alchemy.Core.GetBlock(types.BlockTagOrHash{
 				BlockTag: "latest",
@@ -142,7 +142,7 @@ func TestSenario_DeployContract(t *testing.T) {
 			})
 
 			assert.Nil(t, err)
-			assert.Equal(t, code[2:10], artifacts.PotetoStorageMetaData.Bin[2:10])
+			assert.Equal(t, code[:10], artifacts.PotetoStorageMetaData.Bin[:10])
 
 			t.Run("can get transaction & its receipt form deployed block", func(t *testing.T) {
 				txHash := block.Body().Transactions[0].Hash()

--- a/ether/ether.go
+++ b/ether/ether.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"golang.org/x/crypto/sha3"
 
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
@@ -281,7 +282,7 @@ func (ether *Ether) CodeAt(address string, blockTag string) (string, error) {
 		return "", err
 	}
 
-	return common.Bytes2Hex(code), nil
+	return hexutil.Encode(code), nil
 }
 
 func (ether *Ether) CodeAtHash(address string, blockHash string) (string, error) {
@@ -302,7 +303,7 @@ func (ether *Ether) CodeAtHash(address string, blockHash string) (string, error)
 		return "", err
 	}
 
-	return common.Bytes2Hex(code), nil
+	return hexutil.Encode(code), nil
 }
 
 func (ether *Ether) GetTransaction(hash string) (*gethTypes.Transaction, bool, error) {

--- a/ether/ether_core_test.go
+++ b/ether/ether_core_test.go
@@ -387,7 +387,24 @@ func TestEther_CodeAt(t *testing.T) {
 
 			// Assert
 			assert.NoError(t, err)
-			assert.Equal(t, "608060405234801561001057600080fd5b50", result)
+			assert.Equal(t, "0x608060405234801561001057600080fd5b50", result)
+		})
+
+		t.Run("returns 0x for EOA (empty code)", func(t *testing.T) {
+			// Arrange
+			ether := newEtherApiForTest()
+			alchemyMock := newAlchemyMockOnEtherTest(t)
+			defer alchemyMock.DeactivateAndReset()
+
+			// Mock
+			alchemyMock.RegisterResponderOnce("eth_getCode", `{"jsonrpc":"2.0","id":1,"result":"0x"}`)
+
+			// Act
+			result, err := ether.CodeAt("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", "latest")
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, "0x", result)
 		})
 	})
 
@@ -461,7 +478,24 @@ func TestEther_CodeAtHash(t *testing.T) {
 
 			// Assert
 			assert.NoError(t, err)
-			assert.Equal(t, "608060405234801561001057600080fd5b50", result)
+			assert.Equal(t, "0x608060405234801561001057600080fd5b50", result)
+		})
+
+		t.Run("returns 0x for EOA (empty code)", func(t *testing.T) {
+			// Arrange
+			ether := newEtherApiForTest()
+			alchemyMock := newAlchemyMockOnEtherTest(t)
+			defer alchemyMock.DeactivateAndReset()
+
+			// Mock
+			alchemyMock.RegisterResponderOnce("eth_getCode", `{"jsonrpc":"2.0","id":1,"result":"0x"}`)
+
+			// Act
+			result, err := ether.CodeAtHash("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", "0xbd05b61cc68595a7c30039b2b092ea293c9a2faee20158d578528e399f4d4244")
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, "0x", result)
 		})
 	})
 

--- a/namespace/core_namespace_test.go
+++ b/namespace/core_namespace_test.go
@@ -442,7 +442,7 @@ func TestCore_IsContractAddress(t *testing.T) {
 		assert.False(t, isContractAddress)
 	})
 
-	t.Run("call core.GetCode & if starts w/ 0x is return false", func(t *testing.T) {
+	t.Run("EOA (CodeAt returns \"0x\") returns false", func(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
@@ -466,7 +466,7 @@ func TestCore_IsContractAddress(t *testing.T) {
 		assert.False(t, isContractAddress)
 	})
 
-	t.Run("call core.GetCode & if not starts w/ 0x is return true", func(t *testing.T) {
+	t.Run("contract (CodeAt returns 0x-prefixed bytecode) returns true", func(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
@@ -479,7 +479,7 @@ func TestCore_IsContractAddress(t *testing.T) {
 			reflect.TypeOf(api),
 			"CodeAt",
 			func(_ *ether.Ether, _ string, _ string) (string, error) {
-				return "contract", nil
+				return "0x608060405234801561001057600080fd5b50", nil
 			},
 		)
 


### PR DESCRIPTION
## Summary

Fixes #325 and #318 with separate commits.

- **#325** — `Ether.CodeAt` / `Ether.CodeAtHash` now return `0x`-prefixed hex (via `hexutil.Encode`), matching the `eth_getCode` JSON-RPC convention (`\"0x\"` for empty, `\"0x...\"` for non-empty).
- **#318** — `namespace.Core.IsContractAddress` is now correct as a side-effect of #325. The unit test was also using an unrealistic `\"contract\"` mock for `CodeAt`; it now mocks the real `0x`-prefixed output so it catches future regressions.

## Test plan

- [x] `go test ./ether/...` — passes (includes new EOA case for both `CodeAt` and `CodeAtHash`).
- [x] `go test ./namespace/...` — passes (`TestCore_IsContractAddress` now uses realistic mocks).
- [x] `go build ./...` — clean.
- [ ] e2e (`just ci-e2e`) — requires Anvil/port setup; the `code[:8]` assertion in `e2e/scenario_test.go` was shifted to `code[2:10]` to account for the new `0x` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)