### PR TITLE
:bug: Fix exponential backoff growth and RandomF64 integer division

### DIFF
--- a/internal/backoff.go
+++ b/internal/backoff.go
@@ -61,5 +61,7 @@ func (b *BackoffManager) calculateExponentialBackOffDelay() float64 {
 		return float64(0)
 	}
 
-	return math.Min(b.lastDelay+(utils.RandomF64(1)-0.5)*b.lastDelay, b.config.MaxDelayMs)
+	base := b.lastDelay * 2
+	jitter := (utils.RandomF64(1) - 0.5) * base
+	return math.Min(base+jitter, b.config.MaxDelayMs)
 }

--- a/internal/backoff_test.go
+++ b/internal/backoff_test.go
@@ -3,8 +3,10 @@ package internal
 import (
 	"testing"
 
+	"github.com/agiledragon/gomonkey"
 	"github.com/poteto-go/go-alchemy-sdk/constant"
 	"github.com/poteto-go/go-alchemy-sdk/types"
+	"github.com/poteto-go/go-alchemy-sdk/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -73,5 +75,99 @@ func TestBackoffManager_Backoff(t *testing.T) {
 			assert.ErrorIs(t, err, constant.ErrOverMaxRetries)
 		})
 
+	})
+}
+
+func TestBackoffManager_calculateExponentialBackOffDelay(t *testing.T) {
+	t.Run("first retry returns 0", func(t *testing.T) {
+		// Arrange
+		manager := NewBackoffManager(backoffConfigTest)
+
+		// Act
+		delay := manager.calculateExponentialBackOffDelay()
+
+		// Assert
+		assert.Equal(t, float64(0), delay)
+	})
+
+	t.Run("grows exponentially (doubles) without jitter", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Mock RandomF64 to return 0.5 so jitter term is 0
+		patches.ApplyFunc(utils.RandomF64, func(max float64) float64 {
+			return 0.5
+		})
+
+		// Arrange
+		config := types.BackoffConfig{
+			Mode:           "exponential",
+			MaxRetries:     10,
+			InitialDelayMs: 10,
+			MaxDelayMs:     100000,
+		}
+		manager := NewBackoffManager(config)
+		manager.retries = 1
+		manager.lastDelay = 10
+
+		// Act
+		delay := manager.calculateExponentialBackOffDelay()
+
+		// Assert: base is doubled (10 * 2 = 20), jitter is 0 -> 20
+		assert.Equal(t, float64(20), delay)
+	})
+
+	t.Run("jitter at lower bound returns base * 0.5", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Mock RandomF64 to return 0 -> jitter is -0.5 * base
+		patches.ApplyFunc(utils.RandomF64, func(max float64) float64 {
+			return 0
+		})
+
+		// Arrange
+		config := types.BackoffConfig{
+			Mode:           "exponential",
+			MaxRetries:     10,
+			InitialDelayMs: 10,
+			MaxDelayMs:     100000,
+		}
+		manager := NewBackoffManager(config)
+		manager.retries = 1
+		manager.lastDelay = 10
+
+		// Act
+		delay := manager.calculateExponentialBackOffDelay()
+
+		// Assert: base = 20, jitter = -10, result = 10
+		assert.Equal(t, float64(10), delay)
+	})
+
+	t.Run("capped at MaxDelayMs", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Mock RandomF64 returning 0.5 so jitter is 0
+		patches.ApplyFunc(utils.RandomF64, func(max float64) float64 {
+			return 0.5
+		})
+
+		// Arrange
+		config := types.BackoffConfig{
+			Mode:           "exponential",
+			MaxRetries:     10,
+			InitialDelayMs: 10,
+			MaxDelayMs:     30,
+		}
+		manager := NewBackoffManager(config)
+		manager.retries = 1
+		manager.lastDelay = 20
+
+		// Act
+		delay := manager.calculateExponentialBackOffDelay()
+
+		// Assert: base = 40, capped at 30
+		assert.Equal(t, float64(30), delay)
 	})
 }

--- a/utils/random.go
+++ b/utils/random.go
@@ -6,9 +6,10 @@ import (
 )
 
 func RandomF64(max float64) float64 {
-	nBig, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+	const denom = 1 << 53
+	nBig, err := rand.Int(rand.Reader, big.NewInt(denom))
 	if err != nil {
 		panic(err)
 	}
-	return float64(nBig.Int64() / int64(max))
+	return float64(nBig.Int64()) / float64(denom) * max
 }

--- a/utils/random_test.go
+++ b/utils/random_test.go
@@ -21,9 +21,43 @@ func TestRandomF64(t *testing.T) {
 		assert.Condition(
 			t,
 			func() bool {
-				return val >= 0 && val <= 1
+				return val >= 0 && val < 1
 			},
 		)
+	})
+
+	t.Run("returns distributed values whose mean approaches max/2", func(t *testing.T) {
+		// Arrange
+		const iterations = 1000
+		const max = 1.0
+		sum := 0.0
+
+		// Act
+		for i := 0; i < iterations; i++ {
+			sum += utils.RandomF64(max)
+		}
+		mean := sum / float64(iterations)
+
+		// Assert: mean should be close to max/2 (0.5) with reasonable tolerance
+		assert.InDelta(t, max/2, mean, 0.05)
+	})
+
+	t.Run("scales with max", func(t *testing.T) {
+		// Arrange
+		const iterations = 1000
+		const max = 10.0
+		hasNonZero := false
+
+		// Act & Assert: values should be in [0, max) and not all zero
+		for i := 0; i < iterations; i++ {
+			val := utils.RandomF64(max)
+			assert.GreaterOrEqual(t, val, 0.0)
+			assert.Less(t, val, max)
+			if val > 0 {
+				hasNonZero = true
+			}
+		}
+		assert.True(t, hasNonZero, "expected at least one non-zero value")
 	})
 
 	t.Run("panic case:", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix `BackoffManager.calculateExponentialBackOffDelay` to actually grow exponentially (`lastDelay * 2` as base, then ±50% jitter). Previously the delay only jittered around `lastDelay` with no growth factor. refs: #338
- Fix `utils.RandomF64` to return a uniformly distributed `float64` in `[0, max)`. Previously `nBig.Int64() / int64(max)` integer-divided to `0`, so jitter was always `-0.5 * lastDelay`. refs: #334

These two issues were entangled: fixing only one would still leave backoff broken. They are addressed together as recommended in #338.

## Test plan
- [x] Added `TestBackoffManager_calculateExponentialBackOffDelay` with subtests:
  - first retry returns 0
  - base doubles when jitter is 0
  - jitter at lower bound returns `base * 0.5`
  - result is capped at `MaxDelayMs`
- [x] Tightened `TestRandomF64`:
  - mean of 1000 samples approaches `max/2` within 0.05
  - 1000 samples include at least one non-zero value when `max = 10`
- [x] `go test ./... ` (excluding e2e which requires a running container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)