### PR TITLE
:lock: Guard wallet provider/erc20 reads with RLock to fix race. refs: #332

### DIFF
--- a/wallet/erc20.go
+++ b/wallet/erc20.go
@@ -88,7 +88,7 @@ type walletERC20 struct {
 }
 
 func (api *walletERC20) Transfer(contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
-	provider, _ := api.w.snapshot()
+	provider := api.w.snapshot()
 	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
@@ -133,7 +133,7 @@ func resolveGasLimit(gasLimit *uint64) uint64 {
 }
 
 func (api *walletERC20) TransferNoWait(contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
-	provider, _ := api.w.snapshot()
+	provider := api.w.snapshot()
 	if provider == nil {
 		return common.Hash{}, constant.ErrWalletIsNotConnected
 	}
@@ -159,7 +159,7 @@ func (api *walletERC20) TransferNoWait(contractAddress, toAddress string, amount
 }
 
 func (api *walletERC20) ApproveNoWait(contractAddress, spenderAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
-	provider, _ := api.w.snapshot()
+	provider := api.w.snapshot()
 	if provider == nil {
 		return common.Hash{}, constant.ErrWalletIsNotConnected
 	}
@@ -185,7 +185,7 @@ func (api *walletERC20) ApproveNoWait(contractAddress, spenderAddress string, am
 }
 
 func (api *walletERC20) Approve(contractAddress, spenderAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
-	provider, _ := api.w.snapshot()
+	provider := api.w.snapshot()
 	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
@@ -199,7 +199,7 @@ func (api *walletERC20) Approve(contractAddress, spenderAddress string, amount *
 }
 
 func (api *walletERC20) TransferFromNoWait(contractAddress, fromAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
-	provider, _ := api.w.snapshot()
+	provider := api.w.snapshot()
 	if provider == nil {
 		return common.Hash{}, constant.ErrWalletIsNotConnected
 	}
@@ -226,7 +226,7 @@ func (api *walletERC20) TransferFromNoWait(contractAddress, fromAddress, toAddre
 }
 
 func (api *walletERC20) TransferFrom(contractAddress, fromAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
-	provider, _ := api.w.snapshot()
+	provider := api.w.snapshot()
 	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
@@ -240,8 +240,8 @@ func (api *walletERC20) TransferFrom(contractAddress, fromAddress, toAddress str
 }
 
 func (api *walletERC20) BalanceOf(contractAddress string) (*big.Int, error) {
-	provider, erc20 := api.w.snapshot()
-	if provider == nil {
+	erc20 := api.w.snapshotERC20()
+	if erc20 == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
@@ -252,8 +252,8 @@ func (api *walletERC20) BalanceOf(contractAddress string) (*big.Int, error) {
 }
 
 func (api *walletERC20) TotalSupply(contractAddress string) (*big.Int, error) {
-	provider, erc20 := api.w.snapshot()
-	if provider == nil {
+	erc20 := api.w.snapshotERC20()
+	if erc20 == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
@@ -261,8 +261,8 @@ func (api *walletERC20) TotalSupply(contractAddress string) (*big.Int, error) {
 }
 
 func (api *walletERC20) Allowance(contractAddress, owner, spender string) (*big.Int, error) {
-	provider, erc20 := api.w.snapshot()
-	if provider == nil {
+	erc20 := api.w.snapshotERC20()
+	if erc20 == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
@@ -270,8 +270,8 @@ func (api *walletERC20) Allowance(contractAddress, owner, spender string) (*big.
 }
 
 func (api *walletERC20) Name(contractAddress string) (string, error) {
-	provider, erc20 := api.w.snapshot()
-	if provider == nil {
+	erc20 := api.w.snapshotERC20()
+	if erc20 == nil {
 		return "", constant.ErrWalletIsNotConnected
 	}
 
@@ -279,8 +279,8 @@ func (api *walletERC20) Name(contractAddress string) (string, error) {
 }
 
 func (api *walletERC20) Symbol(contractAddress string) (string, error) {
-	provider, erc20 := api.w.snapshot()
-	if provider == nil {
+	erc20 := api.w.snapshotERC20()
+	if erc20 == nil {
 		return "", constant.ErrWalletIsNotConnected
 	}
 
@@ -288,8 +288,8 @@ func (api *walletERC20) Symbol(contractAddress string) (string, error) {
 }
 
 func (api *walletERC20) Decimals(contractAddress string) (uint8, error) {
-	provider, erc20 := api.w.snapshot()
-	if provider == nil {
+	erc20 := api.w.snapshotERC20()
+	if erc20 == nil {
 		return 0, constant.ErrWalletIsNotConnected
 	}
 

--- a/wallet/erc20.go
+++ b/wallet/erc20.go
@@ -88,7 +88,8 @@ type walletERC20 struct {
 }
 
 func (api *walletERC20) Transfer(contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
-	if api.w.provider == nil {
+	provider, _ := api.w.snapshot()
+	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
@@ -102,7 +103,7 @@ func (api *walletERC20) Transfer(contractAddress, toAddress string, amount *big.
 		return nil, err
 	}
 
-	return api.w.provider.Eth().WaitMined(txHash)
+	return provider.Eth().WaitMined(txHash)
 }
 
 func buildERC20TxData(signature []byte, params ...[]byte) ([]byte, error) {
@@ -132,7 +133,8 @@ func resolveGasLimit(gasLimit *uint64) uint64 {
 }
 
 func (api *walletERC20) TransferNoWait(contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
-	if api.w.provider == nil {
+	provider, _ := api.w.snapshot()
+	if provider == nil {
 		return common.Hash{}, constant.ErrWalletIsNotConnected
 	}
 
@@ -157,7 +159,8 @@ func (api *walletERC20) TransferNoWait(contractAddress, toAddress string, amount
 }
 
 func (api *walletERC20) ApproveNoWait(contractAddress, spenderAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
-	if api.w.provider == nil {
+	provider, _ := api.w.snapshot()
+	if provider == nil {
 		return common.Hash{}, constant.ErrWalletIsNotConnected
 	}
 
@@ -182,7 +185,8 @@ func (api *walletERC20) ApproveNoWait(contractAddress, spenderAddress string, am
 }
 
 func (api *walletERC20) Approve(contractAddress, spenderAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
-	if api.w.provider == nil {
+	provider, _ := api.w.snapshot()
+	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
@@ -191,11 +195,12 @@ func (api *walletERC20) Approve(contractAddress, spenderAddress string, amount *
 		return nil, err
 	}
 
-	return api.w.provider.Eth().WaitMined(txHash)
+	return provider.Eth().WaitMined(txHash)
 }
 
 func (api *walletERC20) TransferFromNoWait(contractAddress, fromAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
-	if api.w.provider == nil {
+	provider, _ := api.w.snapshot()
+	if provider == nil {
 		return common.Hash{}, constant.ErrWalletIsNotConnected
 	}
 
@@ -221,7 +226,8 @@ func (api *walletERC20) TransferFromNoWait(contractAddress, fromAddress, toAddre
 }
 
 func (api *walletERC20) TransferFrom(contractAddress, fromAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
-	if api.w.provider == nil {
+	provider, _ := api.w.snapshot()
+	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
@@ -230,56 +236,62 @@ func (api *walletERC20) TransferFrom(contractAddress, fromAddress, toAddress str
 		return nil, err
 	}
 
-	return api.w.provider.Eth().WaitMined(txHash)
+	return provider.Eth().WaitMined(txHash)
 }
 
 func (api *walletERC20) BalanceOf(contractAddress string) (*big.Int, error) {
-	if api.w.provider == nil {
+	provider, erc20 := api.w.snapshot()
+	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
-	return api.w.erc20.BalanceOf(
+	return erc20.BalanceOf(
 		contractAddress,
 		api.w.GetAddress(),
 	)
 }
 
 func (api *walletERC20) TotalSupply(contractAddress string) (*big.Int, error) {
-	if api.w.provider == nil {
+	provider, erc20 := api.w.snapshot()
+	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
-	return api.w.erc20.TotalSupply(contractAddress)
+	return erc20.TotalSupply(contractAddress)
 }
 
 func (api *walletERC20) Allowance(contractAddress, owner, spender string) (*big.Int, error) {
-	if api.w.provider == nil {
+	provider, erc20 := api.w.snapshot()
+	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
-	return api.w.erc20.Allowance(contractAddress, owner, spender)
+	return erc20.Allowance(contractAddress, owner, spender)
 }
 
 func (api *walletERC20) Name(contractAddress string) (string, error) {
-	if api.w.provider == nil {
+	provider, erc20 := api.w.snapshot()
+	if provider == nil {
 		return "", constant.ErrWalletIsNotConnected
 	}
 
-	return api.w.erc20.Name(contractAddress)
+	return erc20.Name(contractAddress)
 }
 
 func (api *walletERC20) Symbol(contractAddress string) (string, error) {
-	if api.w.provider == nil {
+	provider, erc20 := api.w.snapshot()
+	if provider == nil {
 		return "", constant.ErrWalletIsNotConnected
 	}
 
-	return api.w.erc20.Symbol(contractAddress)
+	return erc20.Symbol(contractAddress)
 }
 
 func (api *walletERC20) Decimals(contractAddress string) (uint8, error) {
-	if api.w.provider == nil {
+	provider, erc20 := api.w.snapshot()
+	if provider == nil {
 		return 0, constant.ErrWalletIsNotConnected
 	}
 
-	return api.w.erc20.Decimals(contractAddress)
+	return erc20.Decimals(contractAddress)
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -155,17 +155,27 @@ func (w *wallet) GetAddress() string {
 	return common.HexToAddress(address.Hex()).String()
 }
 
-// snapshot returns the current provider and erc20 namespace under read lock.
-// Callers should use the returned values for the remainder of the call so that
+// snapshot returns the current provider under read lock.
+// Callers should use the returned value for the remainder of the call so that
 // a concurrent Connect cannot tear the interface header mid-read.
-func (w *wallet) snapshot() (types.IAlchemyProvider, namespace.IERC20) {
+func (w *wallet) snapshot() types.IAlchemyProvider {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	return w.provider, w.erc20
+	return w.provider
+}
+
+// snapshotERC20 returns the current erc20 namespace under read lock.
+// Same rationale as snapshot — keeping it as its own getter so future
+// namespaces (erc721, etc.) can be added without piling tuple returns
+// onto a single helper.
+func (w *wallet) snapshotERC20() namespace.IERC20 {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.erc20
 }
 
 func (w *wallet) GetBalance() (*big.Int, error) {
-	provider, _ := w.snapshot()
+	provider := w.snapshot()
 	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
@@ -186,7 +196,7 @@ func (w *wallet) Connect(provider types.IAlchemyProvider) {
 }
 
 func (w *wallet) PendingNonceAt() (uint64, error) {
-	provider, _ := w.snapshot()
+	provider := w.snapshot()
 	if provider == nil {
 		return 0, constant.ErrWalletIsNotConnected
 	}
@@ -201,7 +211,7 @@ func (w *wallet) PendingNonceAt() (uint64, error) {
 
 // sign Transaction by wallet's p8 key
 func (w *wallet) SignTx(txRequest types.TransactionRequest) (*gethTypes.Transaction, error) {
-	provider, _ := w.snapshot()
+	provider := w.snapshot()
 	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
@@ -248,7 +258,7 @@ func (w *wallet) SignTx(txRequest types.TransactionRequest) (*gethTypes.Transact
 }
 
 func (w *wallet) SendTransaction(txRequest types.TransactionRequest) (common.Hash, error) {
-	provider, _ := w.snapshot()
+	provider := w.snapshot()
 	if provider == nil {
 		return common.Hash{}, constant.ErrWalletIsNotConnected
 	}
@@ -266,7 +276,7 @@ func (w *wallet) SendTransaction(txRequest types.TransactionRequest) (common.Has
 }
 
 func (w *wallet) DeployContract(metaData *bind.MetaData) (common.Address, error) {
-	provider, _ := w.snapshot()
+	provider := w.snapshot()
 	if provider == nil {
 		return common.Address{}, constant.ErrWalletIsNotConnected
 	}
@@ -286,7 +296,7 @@ func (w *wallet) DeployContract(metaData *bind.MetaData) (common.Address, error)
 }
 
 func (w *wallet) DeployContractNoWait(metaData *bind.MetaData) (*bind.DeploymentResult, error) {
-	provider, _ := w.snapshot()
+	provider := w.snapshot()
 	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
@@ -309,7 +319,7 @@ func (w *wallet) ContractTransact(
 	contractAddress string,
 	data []byte,
 ) (*gethTypes.Receipt, error) {
-	provider, _ := w.snapshot()
+	provider := w.snapshot()
 	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
@@ -331,7 +341,7 @@ func (w *wallet) ContractTransactNoWait(
 	contractAddress string,
 	data []byte,
 ) (*gethTypes.Transaction, error) {
-	provider, _ := w.snapshot()
+	provider := w.snapshot()
 	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
@@ -356,7 +366,7 @@ func (w *wallet) ContractCall(
 	callData []byte,
 	unpack func([]byte) (any, error),
 ) (any, error) {
-	provider, _ := w.snapshot()
+	provider := w.snapshot()
 	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -155,12 +155,22 @@ func (w *wallet) GetAddress() string {
 	return common.HexToAddress(address.Hex()).String()
 }
 
+// snapshot returns the current provider and erc20 namespace under read lock.
+// Callers should use the returned values for the remainder of the call so that
+// a concurrent Connect cannot tear the interface header mid-read.
+func (w *wallet) snapshot() (types.IAlchemyProvider, namespace.IERC20) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.provider, w.erc20
+}
+
 func (w *wallet) GetBalance() (*big.Int, error) {
-	if w.provider == nil {
+	provider, _ := w.snapshot()
+	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
-	balance, err := w.provider.Eth().GetBalance(w.GetAddress(), "latest")
+	balance, err := provider.Eth().GetBalance(w.GetAddress(), "latest")
 	if err != nil {
 		return nil, err
 	}
@@ -176,14 +186,12 @@ func (w *wallet) Connect(provider types.IAlchemyProvider) {
 }
 
 func (w *wallet) PendingNonceAt() (uint64, error) {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
-
-	if w.provider == nil {
+	provider, _ := w.snapshot()
+	if provider == nil {
 		return 0, constant.ErrWalletIsNotConnected
 	}
 
-	nonce, err := w.provider.Eth().PendingNonceAt(w.GetAddress())
+	nonce, err := provider.Eth().PendingNonceAt(w.GetAddress())
 	if err != nil {
 		return nonce, err
 	}
@@ -193,7 +201,8 @@ func (w *wallet) PendingNonceAt() (uint64, error) {
 
 // sign Transaction by wallet's p8 key
 func (w *wallet) SignTx(txRequest types.TransactionRequest) (*gethTypes.Transaction, error) {
-	if w.provider == nil {
+	provider, _ := w.snapshot()
+	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
@@ -204,7 +213,7 @@ func (w *wallet) SignTx(txRequest types.TransactionRequest) (*gethTypes.Transact
 	txRequest.Nonce = nonce
 
 	// just use for check gas limit
-	estimatedGas, err := w.provider.Eth().EstimateGas(txRequest)
+	estimatedGas, err := provider.Eth().EstimateGas(txRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +226,7 @@ func (w *wallet) SignTx(txRequest types.TransactionRequest) (*gethTypes.Transact
 	}
 	txRequest.GasPrice = estimatedGas
 
-	chainID, err := w.provider.Eth().ChainID()
+	chainID, err := provider.Eth().ChainID()
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +248,8 @@ func (w *wallet) SignTx(txRequest types.TransactionRequest) (*gethTypes.Transact
 }
 
 func (w *wallet) SendTransaction(txRequest types.TransactionRequest) (common.Hash, error) {
-	if w.provider == nil {
+	provider, _ := w.snapshot()
+	if provider == nil {
 		return common.Hash{}, constant.ErrWalletIsNotConnected
 	}
 
@@ -248,7 +258,7 @@ func (w *wallet) SendTransaction(txRequest types.TransactionRequest) (common.Has
 		return common.Hash{}, err
 	}
 
-	if err := w.provider.Eth().SendRawTransaction(signedTx); err != nil {
+	if err := provider.Eth().SendRawTransaction(signedTx); err != nil {
 		return common.Hash{}, err
 	}
 
@@ -256,7 +266,8 @@ func (w *wallet) SendTransaction(txRequest types.TransactionRequest) (common.Has
 }
 
 func (w *wallet) DeployContract(metaData *bind.MetaData) (common.Address, error) {
-	if w.provider == nil {
+	provider, _ := w.snapshot()
+	if provider == nil {
 		return common.Address{}, constant.ErrWalletIsNotConnected
 	}
 
@@ -267,7 +278,7 @@ func (w *wallet) DeployContract(metaData *bind.MetaData) (common.Address, error)
 
 	tx := deployRes.Txs[metaData.ID]
 	// wait for deployment on chain
-	address, err := w.provider.Eth().WaitDeployed(tx.Hash())
+	address, err := provider.Eth().WaitDeployed(tx.Hash())
 	if err != nil {
 		return common.Address{}, err
 	}
@@ -275,7 +286,8 @@ func (w *wallet) DeployContract(metaData *bind.MetaData) (common.Address, error)
 }
 
 func (w *wallet) DeployContractNoWait(metaData *bind.MetaData) (*bind.DeploymentResult, error) {
-	if w.provider == nil {
+	provider, _ := w.snapshot()
+	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
@@ -284,7 +296,7 @@ func (w *wallet) DeployContractNoWait(metaData *bind.MetaData) (*bind.Deployment
 		return nil, err
 	}
 
-	deployRes, err := w.provider.Eth().DeployContract(auth, metaData)
+	deployRes, err := provider.Eth().DeployContract(auth, metaData)
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +309,8 @@ func (w *wallet) ContractTransact(
 	contractAddress string,
 	data []byte,
 ) (*gethTypes.Receipt, error) {
-	if w.provider == nil {
+	provider, _ := w.snapshot()
+	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
@@ -310,7 +323,7 @@ func (w *wallet) ContractTransact(
 		return nil, err
 	}
 
-	return w.provider.Eth().WaitMined(tx.Hash())
+	return provider.Eth().WaitMined(tx.Hash())
 }
 
 func (w *wallet) ContractTransactNoWait(
@@ -318,7 +331,8 @@ func (w *wallet) ContractTransactNoWait(
 	contractAddress string,
 	data []byte,
 ) (*gethTypes.Transaction, error) {
-	if w.provider == nil {
+	provider, _ := w.snapshot()
+	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
@@ -327,7 +341,7 @@ func (w *wallet) ContractTransactNoWait(
 		return nil, err
 	}
 
-	tx, err := w.provider.Eth().ContractTransact(auth, contract, contractAddress, data)
+	tx, err := provider.Eth().ContractTransact(auth, contract, contractAddress, data)
 	if err != nil {
 		return nil, err
 	}
@@ -342,12 +356,13 @@ func (w *wallet) ContractCall(
 	callData []byte,
 	unpack func([]byte) (any, error),
 ) (any, error) {
-	if w.provider == nil {
+	provider, _ := w.snapshot()
+	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
 	addr := common.HexToAddress(contractAddress)
-	return w.provider.Eth().ContractCall(contract, addr, opts, callData, unpack)
+	return provider.Eth().ContractCall(contract, addr, opts, callData, unpack)
 }
 
 func (w *wallet) ERC20() WalletERC20 {

--- a/wallet/wallet_race_test.go
+++ b/wallet/wallet_race_test.go
@@ -1,0 +1,271 @@
+package wallet
+
+import (
+	"math/big"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/agiledragon/gomonkey"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
+	"github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/poteto-go/go-alchemy-sdk/_fixture/artifacts"
+	"github.com/poteto-go/go-alchemy-sdk/ether"
+	"github.com/poteto-go/go-alchemy-sdk/gas"
+	"github.com/poteto-go/go-alchemy-sdk/namespace"
+	"github.com/poteto-go/go-alchemy-sdk/types"
+)
+
+// TestWallet_NoRaceConnectVsReaders verifies that concurrent calls to
+// Connect and reader methods do not race on w.provider / w.erc20.
+// Must be run with -race to catch unsynchronized field access.
+// Refs: https://github.com/poteto-go/go-alchemy-sdk/issues/332
+func TestWallet_NoRaceConnectVsReaders(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	setting := gas.AlchemySetting{
+		ApiKey:  "api-key",
+		Network: types.EthMainnet,
+	}
+	alchemy, err := gas.NewAlchemy(setting)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := alchemy.GetProvider()
+
+	// Mock everything readers touch so we don't make network calls.
+	patches.ApplyMethod(
+		reflect.TypeOf(provider.Eth()),
+		"GetBalance",
+		func(_ *ether.Ether, _ string, _ string) (*big.Int, error) {
+			return big.NewInt(0), nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(provider.Eth()),
+		"PendingNonceAt",
+		func(_ *ether.Ether, _ string) (uint64, error) {
+			return 0, nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(provider.Eth()),
+		"EstimateGas",
+		func(_ *ether.Ether, _ types.TransactionRequest) (*big.Int, error) {
+			return big.NewInt(1), nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(provider.Eth()),
+		"ChainID",
+		func(_ *ether.Ether) (*big.Int, error) {
+			return big.NewInt(1), nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(provider.Eth()),
+		"SendRawTransaction",
+		func(_ *ether.Ether, _ *gethTypes.Transaction) error {
+			return nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(provider.Eth()),
+		"ContractCall",
+		func(
+			_ *ether.Ether,
+			_ types.ContractInstance,
+			_ common.Address,
+			_ *bind.CallOpts,
+			_ []byte,
+			_ func([]byte) (any, error),
+		) (any, error) {
+			return nil, nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(provider.Eth()),
+		"DeployContract",
+		func(
+			_ *ether.Ether,
+			_ *bind.TransactOpts,
+			_ *bind.MetaData,
+		) (*bind.DeploymentResult, error) {
+			return &bind.DeploymentResult{
+				Txs: map[string]*gethTypes.Transaction{},
+			}, nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(provider.Eth()),
+		"ContractTransact",
+		func(
+			_ *ether.Ether,
+			_ *bind.TransactOpts,
+			_ types.ContractInstance,
+			_ string,
+			_ []byte,
+		) (*gethTypes.Transaction, error) {
+			return gethTypes.NewTx(&gethTypes.LegacyTx{}), nil
+		},
+	)
+
+	w, _ := New(testPrivHex)
+	w.Connect(provider) // ensure erc20 is set before readers start
+
+	contract := artifacts.NewPotetoStorage()
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	callData := []byte("call data")
+	callOpts := &bind.CallOpts{}
+	unpack := func(b []byte) (any, error) { return nil, nil }
+
+	const iterations = 200
+	var wg sync.WaitGroup
+
+	// Writer: re-Connect repeatedly.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			w.Connect(provider)
+		}
+	}()
+
+	// Reader: GetBalance.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_, _ = w.GetBalance()
+		}
+	}()
+
+	// Reader: PendingNonceAt.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_, _ = w.PendingNonceAt()
+		}
+	}()
+
+	// Reader: ContractCall.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_, _ = w.ContractCall(contract, contractAddress, callOpts, callData, unpack)
+		}
+	}()
+
+	// Reader: ContractTransactNoWait (also touches getOrCreateAuth).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_, _ = w.ContractTransactNoWait(contract, contractAddress, callData)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestWallet_NoRaceConnectVsERC20Readers verifies that concurrent Connect
+// calls do not race with walletERC20 readers that touch w.provider / w.erc20.
+// Refs: https://github.com/poteto-go/go-alchemy-sdk/issues/332
+func TestWallet_NoRaceConnectVsERC20Readers(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	setting := gas.AlchemySetting{
+		ApiKey:  "api-key",
+		Network: types.EthMainnet,
+	}
+	alchemy, err := gas.NewAlchemy(setting)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := alchemy.GetProvider()
+
+	patches.ApplyMethod(
+		reflect.TypeOf(&namespace.ERC20{}),
+		"BalanceOf",
+		func(_ *namespace.ERC20, _ string, _ string) (*big.Int, error) {
+			return big.NewInt(0), nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(&namespace.ERC20{}),
+		"TotalSupply",
+		func(_ *namespace.ERC20, _ string) (*big.Int, error) {
+			return big.NewInt(0), nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(&namespace.ERC20{}),
+		"Allowance",
+		func(_ *namespace.ERC20, _, _, _ string) (*big.Int, error) {
+			return big.NewInt(0), nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(&namespace.ERC20{}),
+		"Name",
+		func(_ *namespace.ERC20, _ string) (string, error) {
+			return "", nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(&namespace.ERC20{}),
+		"Symbol",
+		func(_ *namespace.ERC20, _ string) (string, error) {
+			return "", nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(&namespace.ERC20{}),
+		"Decimals",
+		func(_ *namespace.ERC20, _ string) (uint8, error) {
+			return 0, nil
+		},
+	)
+
+	w, _ := New(testPrivHex)
+	w.Connect(provider)
+
+	contractAddress := "0x1234567890123456789012345678901234567890"
+
+	const iterations = 200
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			w.Connect(provider)
+		}
+	}()
+
+	readers := []func(){
+		func() { _, _ = w.ERC20().BalanceOf(contractAddress) },
+		func() { _, _ = w.ERC20().TotalSupply(contractAddress) },
+		func() { _, _ = w.ERC20().Allowance(contractAddress, contractAddress, contractAddress) },
+		func() { _, _ = w.ERC20().Name(contractAddress) },
+		func() { _, _ = w.ERC20().Symbol(contractAddress) },
+		func() { _, _ = w.ERC20().Decimals(contractAddress) },
+	}
+
+	for _, r := range readers {
+		wg.Add(1)
+		go func(read func()) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				read()
+			}
+		}(r)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- `wallet.Connect` wrote `w.provider` / `w.erc20` under `w.mu.Lock()`, but every other reader on `*wallet` and `*walletERC20` touched those fields without any lock — a concurrent Connect could tear the interface header (panic) or expose a stale `nil` (spurious `ErrWalletIsNotConnected`). Fixes #332.
- Introduced `wallet.snapshot()` that returns `(provider, erc20)` under `RLock`. Every reader now snapshots at the top and uses the locals for the rest of the call.
- Added `wallet/wallet_race_test.go` with two race tests (`TestWallet_NoRaceConnectVsReaders`, `TestWallet_NoRaceConnectVsERC20Readers`) that re-Connect concurrently with readers; both fail under `-race` on `main` and pass with this fix.

## Test plan
- [x] `go test ./wallet/ -race -run 'TestWallet_NoRace' -count=1` — races detected on `main`, pass on this branch
- [x] `go test ./wallet/ -race -count=1` — entire wallet suite green with race detector
- [x] `just unit-test` — full unit-test suite green
- [x] `just lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)