### PR TITLE
:bug: make AlchemyProvider.id atomic to prevent JSON-RPC id races (closes #329)

### DIFF
--- a/gas/http_provider.go
+++ b/gas/http_provider.go
@@ -23,6 +23,7 @@ func NewAlchemyProvider(config AlchemyConfig) types.IAlchemyProvider {
 	provider := &AlchemyProvider{
 		config: config,
 	}
+	provider.id.Store(1)
 
 	if config.maxRetries > 0 {
 		provider.batcher = internal.NewRequestBatcher(
@@ -56,7 +57,8 @@ func (provider *AlchemyProvider) CustomHeaders() []http.Header {
 
 /* Send raw transaction */
 func (provider *AlchemyProvider) Send(method string, params types.RequestArgs) (any, error) {
-	id := provider.id.Add(1)
+	// fetch-and-add: take the current id for this request, then advance the counter atomically.
+	id := provider.id.Add(1) - 1
 	body, err := utils.CreateRequestBodyToBytes(int(id), method, params)
 	if err != nil {
 		return nil, err

--- a/gas/http_provider.go
+++ b/gas/http_provider.go
@@ -3,6 +3,7 @@ package gas
 import (
 	"context"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/poteto-go/go-alchemy-sdk/constant"
@@ -13,7 +14,7 @@ import (
 
 type AlchemyProvider struct {
 	config  AlchemyConfig
-	id      int
+	id      atomic.Int64
 	batcher *internal.RequestBatcher
 	eth     types.EtherApi
 }
@@ -21,7 +22,6 @@ type AlchemyProvider struct {
 func NewAlchemyProvider(config AlchemyConfig) types.IAlchemyProvider {
 	provider := &AlchemyProvider{
 		config: config,
-		id:     1,
 	}
 
 	if config.maxRetries > 0 {
@@ -56,7 +56,8 @@ func (provider *AlchemyProvider) CustomHeaders() []http.Header {
 
 /* Send raw transaction */
 func (provider *AlchemyProvider) Send(method string, params types.RequestArgs) (any, error) {
-	body, err := utils.CreateRequestBodyToBytes(provider.id, method, params)
+	id := provider.id.Add(1)
+	body, err := utils.CreateRequestBodyToBytes(int(id), method, params)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +81,6 @@ func send(provider *AlchemyProvider, body []byte) (any, error) {
 			if err != nil {
 				return "", err
 			}
-			provider.id++
 			return fmt.Sprintf("%v", response.Result), nil
 		}
 	*/
@@ -103,8 +103,6 @@ func send(provider *AlchemyProvider, body []byte) (any, error) {
 	if result == nil {
 		return nil, constant.ErrResultIsNil
 	}
-
-	provider.id++
 
 	return result, nil
 }

--- a/gas/http_provider_test.go
+++ b/gas/http_provider_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/agiledragon/gomonkey"
@@ -36,7 +37,7 @@ func TestNewAlchemyProvider(t *testing.T) {
 
 	// Assert
 	assert.Equal(t, config, provider.config)
-	assert.Equal(t, 1, provider.id)
+	assert.Equal(t, int64(0), provider.id.Load())
 	assert.Equal(t, config.customHeaders, customHeaders)
 }
 
@@ -78,7 +79,55 @@ func TestAlchemyProvider_Send(t *testing.T) {
 			// Assert
 			assert.NoError(t, err)
 			assert.Equal(t, "0x1234", result)
-			assert.Equal(t, 2, provider.id)
+			assert.Equal(t, int64(1), provider.id.Load())
+		})
+
+		t.Run("concurrent Send produces unique JSON-RPC ids", func(t *testing.T) {
+			provider := newProviderForTest()
+			provider.config.backoffConfig.MaxRetries = 0
+
+			httpmock.Activate(t)
+			defer httpmock.DeactivateAndReset()
+
+			var (
+				mu  sync.Mutex
+				ids []int
+			)
+			httpmock.RegisterResponder(
+				"POST",
+				provider.config.GetUrl(),
+				func(req *http.Request) (*http.Response, error) {
+					var body types.AlchemyRequestBody
+					if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+						return nil, err
+					}
+					mu.Lock()
+					ids = append(ids, body.Id)
+					mu.Unlock()
+					return httpmock.NewStringResponse(
+						200,
+						`{"jsonrpc":"2.0","id":1,"result":"0x1"}`,
+					), nil
+				},
+			)
+
+			const goroutines = 50
+			var wg sync.WaitGroup
+			for i := 0; i < goroutines; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					_, _ = provider.Send("hoge", types.RequestArgs{})
+				}()
+			}
+			wg.Wait()
+
+			assert.Len(t, ids, goroutines)
+			seen := map[int]bool{}
+			for _, id := range ids {
+				assert.Falsef(t, seen[id], "duplicate JSON-RPC id %d generated under concurrency", id)
+				seen[id] = true
+			}
 		})
 	})
 

--- a/gas/http_provider_test.go
+++ b/gas/http_provider_test.go
@@ -37,7 +37,7 @@ func TestNewAlchemyProvider(t *testing.T) {
 
 	// Assert
 	assert.Equal(t, config, provider.config)
-	assert.Equal(t, int64(0), provider.id.Load())
+	assert.Equal(t, int64(1), provider.id.Load())
 	assert.Equal(t, config.customHeaders, customHeaders)
 }
 
@@ -79,7 +79,7 @@ func TestAlchemyProvider_Send(t *testing.T) {
 			// Assert
 			assert.NoError(t, err)
 			assert.Equal(t, "0x1234", result)
-			assert.Equal(t, int64(1), provider.id.Load())
+			assert.Equal(t, int64(2), provider.id.Load())
 		})
 
 		t.Run("concurrent Send produces unique JSON-RPC ids", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Switch `AlchemyProvider.id` from a plain `int` mutated with `provider.id++` to `atomic.Int64`, and allocate the id with `provider.id.Add(1)` at the top of `Send` before constructing the request body.
- Drop the now-redundant `provider.id++` after the response, and the same commented-out increment in the batcher branch — the id is allocated atomically up-front regardless of outcome.
- Add a concurrent `Send` test (50 goroutines against an httpmock-captured RPC endpoint) that decodes each request body and asserts every JSON-RPC id is unique. This test fails on `main` (many duplicate ids) and passes after the fix.

Fixes the race described in #329 — concurrent `Send` calls (e.g. via a shared `Alchemy.Core` / `Alchemy.ERC20`) no longer collide on the same id, which matters today for traceability and is load-bearing for the future batched path that uses the id to match request ↔ response.

## Test plan

- [x] `go test ./gas/ -run TestAlchemyProvider_Send/normal_case/concurrent_Send -v` fails on `main` and passes on this branch
- [x] `go test ./gas/ -race -v` is green
- [x] `just ut` — full unit-test suite green
- [x] `just lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)