### PR TITLE
:bug: Fix SetEthClient/Close concurrency races (closes #324)

### DIFF
--- a/ether/ether.go
+++ b/ether/ether.go
@@ -59,6 +59,7 @@ func (ether *Ether) SetEthClient() error {
 
 	rpcClient, err := ether.createRpcClient()
 	if err != nil {
+		ether.connCount--
 		return err
 	}
 
@@ -195,6 +196,8 @@ func (ether *Ether) Close() {
 }
 
 func (ether *Ether) Client() *ethclient.Client {
+	ether.mu.Lock()
+	defer ether.mu.Unlock()
 	return ether.client
 }
 

--- a/ether/ether.go
+++ b/ether/ether.go
@@ -47,15 +47,15 @@ func NewEtherApi(provider types.IAlchemyProvider, config EtherApiConfig) types.E
 }
 
 func (ether *Ether) SetEthClient() error {
-	ether.connCount += 1
+	ether.mu.Lock()
+	defer ether.mu.Unlock()
+
+	ether.connCount++
 	if ether.isClientJwsAlive() {
 		return nil
 	}
 
 	ether.kill()
-
-	ether.mu.Lock()
-	defer ether.mu.Unlock()
 
 	rpcClient, err := ether.createRpcClient()
 	if err != nil {
@@ -179,11 +179,14 @@ func (ether *Ether) generateAndSetAuthorization(rpcClient *rpc.Client) error {
 }
 
 func (ether *Ether) Close() {
+	ether.mu.Lock()
+	defer ether.mu.Unlock()
+
 	if ether.client == nil {
 		return
 	}
 
-	ether.connCount -= 1
+	ether.connCount--
 	if ether.connCount > 0 {
 		return
 	}

--- a/ether/ether_core_test.go
+++ b/ether/ether_core_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"net/http"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -143,6 +144,21 @@ func TestEther_SetEthClientAndClose(t *testing.T) {
 		// Assert
 		assert.Nil(t, ether.Client())
 	})
+}
+
+func TestEther_SetEthClientAndClose_Race(t *testing.T) {
+	const goroutines = 10
+	e := newEtherApiForTest()
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_ = e.SetEthClient()
+			e.Close()
+		}()
+	}
+	wg.Wait()
 }
 
 func TestEther_BlockNumber(t *testing.T) {

--- a/ether/ether_core_test.go
+++ b/ether/ether_core_test.go
@@ -155,7 +155,31 @@ func TestEther_SetEthClientAndClose_Race(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			_ = e.SetEthClient()
+			_ = e.Client()
 			e.Close()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestEther_Client_Race(t *testing.T) {
+	e := newEtherApiForTest()
+	var wg sync.WaitGroup
+	const readers = 20
+	const writers = 5
+	wg.Add(writers)
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			_ = e.SetEthClient()
+			e.Close()
+		}()
+	}
+	wg.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			_ = e.Client()
 		}()
 	}
 	wg.Wait()

--- a/ether/ether_whitebox_test.go
+++ b/ether/ether_whitebox_test.go
@@ -1,0 +1,25 @@
+package ether
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEther_SetEthClient_ConnCountRollbackOnError verifies that a failed
+// SetEthClient does not permanently inflate connCount (issue #324).
+func TestEther_SetEthClient_ConnCountRollbackOnError(t *testing.T) {
+	e := &Ether{
+		config: NewEtherApiConfig("", 0, time.Duration(0), nil, nil, []byte(""), 0),
+		mu:     &sync.Mutex{},
+	}
+
+	// Act: SetEthClient with an empty URL must fail at createRpcClient.
+	err := e.SetEthClient()
+
+	// Assert: error surfaced, and connCount was rolled back to 0.
+	assert.Error(t, err)
+	assert.Equal(t, 0, e.connCount, "connCount must not leak on error")
+}


### PR DESCRIPTION
## Summary

- Move `mu.Lock()` to the very top of `SetEthClient` and `Close` so every read and write of `connCount` and `client` happens under the mutex
- Removes the window where two goroutines could concurrently corrupt `connCount` (+1/+1 → +1) or race on `client` nil-check / `kill()` / assignment
- Add `TestEther_SetEthClientAndClose_Race` — a concurrent test that runs 10 goroutines calling `SetEthClient()`/`Close()` in parallel; confirmed to trigger a data-race report with `-race` **before** the fix and pass cleanly **after**

## Root cause

`SetEthClient` incremented `connCount` and called `isClientJwsAlive`/`kill` before acquiring `mu`, while `Close` read `client` and decremented `connCount` outside the lock entirely. The mutex only covered the final client assignment, leaving every other shared-state access unguarded.

## Test plan

- [x] `go test -race -run TestEther_SetEthClientAndClose_Race ./ether/` → FAIL (data race) before fix, PASS after
- [x] `go test -race -run TestEther_SetEthClientAndClose ./ether/` → PASS (existing single-goroutine tests still pass)
- [x] `go test -gcflags=all=-l ./ether/...` → all 1 package green

🤖 Generated with [Claude Code](https://claude.com/claude-code)