### PR TITLE
:bug: Fix GetTokenBalances type assertion always fails in production

### DIFF
--- a/ether/ether.go
+++ b/ether/ether.go
@@ -341,13 +341,21 @@ func (ether *Ether) GetTokenBalances(address string, params ...string) (types.To
 		return types.TokenBalanceResponse{}, constant.ErrUnexpectedResponseType
 	}
 	if balances, exists := resultMap["tokenBalances"]; exists {
-		balanceSlice, ok := balances.([]map[string]any)
+		balancesAny, ok := balances.([]any)
 		if !ok {
 			return types.TokenBalanceResponse{}, constant.ErrUnexpectedResponseType
 		}
-		for _, balance := range balanceSlice {
-			if errStr, ok := balance["error"]; ok && errStr != nil {
-				balance["error"] = errors.New(errStr.(string))
+		for _, b := range balancesAny {
+			bm, ok := b.(map[string]any)
+			if !ok {
+				return types.TokenBalanceResponse{}, constant.ErrUnexpectedResponseType
+			}
+			if errStr, ok := bm["error"]; ok && errStr != nil {
+				s, ok := errStr.(string)
+				if !ok {
+					return types.TokenBalanceResponse{}, constant.ErrUnexpectedResponseType
+				}
+				bm["error"] = errors.New(s)
 			}
 		}
 	}

--- a/ether/ether_core_test.go
+++ b/ether/ether_core_test.go
@@ -758,8 +758,8 @@ func TestEther_GetTokenBalances(t *testing.T) {
 	ether := newNilEtherApiForTest(provider)
 	expectedResponse := map[string]any{
 		"address": "0x123",
-		"tokenBalances": []map[string]any{
-			{
+		"tokenBalances": []any{
+			map[string]any{
 				"contractAddress": "0x456",
 				"tokenBalance":    "0x0000000000000000000000000000000000000000000000000000000000000000",
 				"error":           nil,
@@ -830,8 +830,8 @@ func TestEther_GetTokenBalances(t *testing.T) {
 			// Arrange
 			expectedErrResponse := map[string]any{
 				"address": "0x123",
-				"tokenBalances": []map[string]any{
-					{
+				"tokenBalances": []any{
+					map[string]any{
 						"contractAddress": "0x456",
 						"tokenBalance":    "0x0000000000000000000000000000000000000000000000000000000000000000",
 						"error":           "error",
@@ -888,7 +888,7 @@ func TestEther_GetTokenBalances(t *testing.T) {
 			_, err := ether.GetTokenBalances("0x123")
 
 			// Assert
-			assert.ErrorIs(t, expectedErr, err)
+			assert.ErrorIs(t, err, expectedErr)
 		})
 
 		t.Run("mapstructure error, return constant.ErrFailedToMapTokenResponse", func(t *testing.T) {
@@ -915,7 +915,7 @@ func TestEther_GetTokenBalances(t *testing.T) {
 			_, err := ether.GetTokenBalances("0x123")
 
 			// Assert
-			assert.ErrorIs(t, constant.ErrFailedToMapTokenResponse, err)
+			assert.ErrorIs(t, err, constant.ErrFailedToMapTokenResponse)
 		})
 
 		t.Run("if result is not map[string]any -> ErrUnexpectedResponseType", func(t *testing.T) {
@@ -935,10 +935,10 @@ func TestEther_GetTokenBalances(t *testing.T) {
 			_, err := ether.GetTokenBalances("0x123")
 
 			// Assert
-			assert.ErrorIs(t, constant.ErrUnexpectedResponseType, err)
+			assert.ErrorIs(t, err, constant.ErrUnexpectedResponseType)
 		})
 
-		t.Run("if tokenBalances is not []map[string]any -> ErrUnexpectedResponseType", func(t *testing.T) {
+		t.Run("if tokenBalances is not []any -> ErrUnexpectedResponseType", func(t *testing.T) {
 			patches := gomonkey.NewPatches()
 			defer patches.Reset()
 
@@ -958,7 +958,30 @@ func TestEther_GetTokenBalances(t *testing.T) {
 			_, err := ether.GetTokenBalances("0x123")
 
 			// Assert
-			assert.ErrorIs(t, constant.ErrUnexpectedResponseType, err)
+			assert.ErrorIs(t, err, constant.ErrUnexpectedResponseType)
+		})
+
+		t.Run("if tokenBalances element is not map[string]any -> ErrUnexpectedResponseType", func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			// Mock
+			patches.ApplyMethod(
+				reflect.TypeOf(provider),
+				"Send",
+				func(_ *gas.AlchemyProvider, _ string, _ types.RequestArgs) (any, error) {
+					return map[string]any{
+						"address":       "0x123",
+						"tokenBalances": []any{"not-a-map"},
+					}, nil
+				},
+			)
+
+			// Act
+			_, err := ether.GetTokenBalances("0x123")
+
+			// Assert
+			assert.ErrorIs(t, err, constant.ErrUnexpectedResponseType)
 		})
 	})
 }


### PR DESCRIPTION
## Summary

Fixes #323.

- `GetTokenBalances` was asserting `balances.([]map[string]any)` on data produced by `json.Unmarshal` into `any`. Go's `encoding/json` decodes JSON arrays as `[]interface{}`, not `[]map[string]interface{}`, so the assertion always failed and the function always returned `ErrUnexpectedResponseType` for any real response containing balances.
- The `errStr.(string)` assertion for the `error` field was unguarded — if the API ever returned a non-string value (object, number, etc.) it would panic at runtime.
- Tests mocked `provider.Send` to return `[]map[string]any{...}` directly, bypassing JSON and hiding the bug.

Changes:
- Changed `balances.([]map[string]any)` → `balances.([]any)` with a per-element `.(map[string]any)` cast
- Added comma-ok guard for `errStr.(string)` to return `ErrUnexpectedResponseType` instead of panicking
- Updated test mock data to use `[]any{map[string]any{...}}` matching actual `json.Unmarshal` output
- Added test case for non-`map[string]any` elements in the `tokenBalances` slice
- Fixed reversed `assert.ErrorIs(t, target, err)` argument order in error test cases

## Test plan

- [x] Updated `TestEther_GetTokenBalances` mock data to use `[]any{map[string]any{...}}`
- [x] Added test for non-`map[string]any` element → `ErrUnexpectedResponseType`
- [x] Fixed `assert.ErrorIs` argument order (was `(t, expected, actual)`, now `(t, actual, expected)`)
- [x] `go test ./...` passes for all packages except `e2e` (requires Anvil/port setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)