### PR TITLE
feat: Add ctx to WaitMined/WaitDeployed and waiting wallet methods

### DIFF
--- a/docs/docs/transact-namespace/WaitDeployed.md
+++ b/docs/docs/transact-namespace/WaitDeployed.md
@@ -4,7 +4,7 @@ WaitDeployed waits for a contract deployment transaction with the provided hash 
 It stops waiting when ctx is canceled.
 
 ```go
-func WaitDeployed(txHash string) (contractAddress common.Address, err error)
+func WaitDeployed(ctx context.Context, txHash string) (contractAddress common.Address, err error)
 ```
 
 ```go
@@ -12,6 +12,14 @@ func main() {
 	...
 	alchemy := gas.NewAlchemy(setting)
 	...
-	contractAddress, err := alchemy.Transact.WaitDeployed("<deployedHash>")
+	contractAddress, err := alchemy.Transact.WaitDeployed(context.Background(), "<deployedHash>")
 }
+```
+
+Pass a cancelable context to stop waiting early:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+contractAddress, err := alchemy.Transact.WaitDeployed(ctx, "<deployedHash>")
 ```

--- a/docs/docs/transact-namespace/WaitMined.md
+++ b/docs/docs/transact-namespace/WaitMined.md
@@ -5,13 +5,21 @@ returns the transaction receipt when it is mined.
 It stops waiting when ctx is canceled.
 
 ```go
-func WaitMined(txHash string) (txReceipt *gethTypes.Receipt, err error)
+func WaitMined(ctx context.Context, txHash string) (txReceipt *gethTypes.Receipt, err error)
 ```
 
 ```go
 func main() {
 	...
 	alchemy := gas.NewAlchemy(setting)
-	txReceipt, err := alchemy.Transact.WaitMined("<txHash>")
+	txReceipt, err := alchemy.Transact.WaitMined(context.Background(), "<txHash>")
 }
+```
+
+Pass a cancelable context to stop waiting early:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+txReceipt, err := alchemy.Transact.WaitMined(ctx, "<txHash>")
 ```

--- a/docs/docs/wallet/Approve.md
+++ b/docs/docs/wallet/Approve.md
@@ -15,7 +15,7 @@ It requires connected wallet.
 Wait for the transaction to be mined and return the receipt.
 
 ```go
-func Approve(contractAddress, spenderAddress string, amount *big.Int, gasLimit *uint64) (*types.Receipt, error)
+func Approve(ctx context.Context, contractAddress, spenderAddress string, amount *big.Int, gasLimit *uint64) (*types.Receipt, error)
 ```
 
 ```go
@@ -23,6 +23,7 @@ func main() {
 	// ... setup ...
 
 	receipt, err := w.ERC20().Approve(
+		context.Background(),
 		"<contractAddress>",
 		"<spenderAddress>",
 		big.NewInt(100),

--- a/docs/docs/wallet/ContractTransact.md
+++ b/docs/docs/wallet/ContractTransact.md
@@ -18,6 +18,7 @@ cf.) [`wallet.ContractTransactNoWait`](./ContractTransactNoWait.md)
 
 ```go
 func ContractTransact(
+	ctx context.Context,
 	contract types.ContractInstance,
 	contractAddress string,
 	data []byte,
@@ -43,7 +44,7 @@ func main() {
 	data := abi.PackXXX(<data>)
 
 	// Execute transaction
-	receipt, err := w.ContractTransact(contract, contractAddress, data)
+	receipt, err := w.ContractTransact(context.Background(), contract, contractAddress, data)
 	if err != nil {
 		panic(err)
 	}

--- a/docs/docs/wallet/DeployContract.md
+++ b/docs/docs/wallet/DeployContract.md
@@ -19,7 +19,7 @@ cf.) [`wallet.DeployContractNoWait`](./DeployContractNoWait.md)
 :::
 
 ```go
-func DeployContract(metaData *bind.MetaData) (deployedAddr common.Address, err error)
+func DeployContract(ctx context.Context, metaData *bind.MetaData) (deployedAddr common.Address, err error)
 ```
 
 ```go
@@ -33,7 +33,7 @@ func main() {
 	w, _ := wallet.New("<privateKey>")
 	w.Connect(alchemy.GetProvider())
 
-	address, err := w.DeployContract(&<your-metaData>)
+	address, err := w.DeployContract(context.Background(), &<your-metaData>)
 	if err != nil {
 		panic(err)
 	}

--- a/docs/docs/wallet/ERC20.md
+++ b/docs/docs/wallet/ERC20.md
@@ -66,6 +66,7 @@ func main() {
 
 	// Execute transaction (wait for mined)
 	receipt, err := w.ERC20().Transfer(
+		context.Background(),
 		contractAddress,
 		"<toAddress>",
 		big.NewInt(100),

--- a/docs/docs/wallet/TransferFrom.md
+++ b/docs/docs/wallet/TransferFrom.md
@@ -19,7 +19,7 @@ The connected wallet must have been approved as a spender by the `fromAddress` b
 Wait for the transaction to be mined and return the receipt.
 
 ```go
-func TransferFrom(contractAddress, fromAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*types.Receipt, error)
+func TransferFrom(ctx context.Context, contractAddress, fromAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*types.Receipt, error)
 ```
 
 ```go
@@ -28,6 +28,7 @@ func main() {
 
 	// Assumes fromAddress has already approved the connected wallet as a spender
 	receipt, err := w.ERC20().TransferFrom(
+		context.Background(),
 		"<contractAddress>",
 		"<fromAddress>",
 		"<toAddress>",

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"math/big"
 	"os"
 	"strconv"
@@ -110,7 +111,7 @@ func TestSenario_DeployContract(t *testing.T) {
 
 		w.Connect(alchemy.GetProvider())
 
-		contractAddress, err := w.DeployContract(&artifacts.PotetoStorageMetaData)
+		contractAddress, err := w.DeployContract(context.Background(), &artifacts.PotetoStorageMetaData)
 
 		assert.Nil(t, err)
 		assert.NotEqual(t, contractAddress, common.HexToAddress("0x0"))
@@ -178,7 +179,7 @@ func TestScenario_ERC20(t *testing.T) {
 
 		erc20Metadata := &artifacts.ERC20MetaData
 		deployer.BindDeploymentMetadata(erc20Metadata, big.NewInt(1000))
-		contractAddress, err := w.DeployContract(erc20Metadata)
+		contractAddress, err := w.DeployContract(context.Background(), erc20Metadata)
 
 		assert.Nil(t, err)
 		assert.NotEqual(t, contractAddress, common.HexToAddress("0x0"))
@@ -217,7 +218,7 @@ func TestScenario_ERC20(t *testing.T) {
 		t.Run("Approve: allowance is set to approved amount", func(t *testing.T) {
 			approveAmount := big.NewInt(100)
 
-			_, err := w.ERC20().Approve(contractHex, otherAddress, approveAmount, nil)
+			_, err := w.ERC20().Approve(context.Background(), contractHex, otherAddress, approveAmount, nil)
 			assert.Nil(t, err)
 
 			allowance, err := w.ERC20().Allowance(contractHex, initAddress, otherAddress)
@@ -232,7 +233,7 @@ func TestScenario_ERC20(t *testing.T) {
 			assert.Nil(t, err)
 			assert.NotEqual(t, txHash.Hex(), "0x0000000000000000000000000000000000000000000000000000000000000000")
 
-			_, err = alchemy.Transact.WaitMined(txHash.Hex())
+			_, err = alchemy.Transact.WaitMined(context.Background(), txHash.Hex())
 			assert.Nil(t, err)
 
 			allowance, err := w.ERC20().Allowance(contractHex, initAddress, otherAddress)
@@ -243,7 +244,7 @@ func TestScenario_ERC20(t *testing.T) {
 		t.Run("TransferFrom: otherWallet transfers from initAddress after approval", func(t *testing.T) {
 			transferAmount := big.NewInt(50)
 
-			_, err := w.ERC20().Approve(contractHex, otherAddress, transferAmount, nil)
+			_, err := w.ERC20().Approve(context.Background(), contractHex, otherAddress, transferAmount, nil)
 			assert.Nil(t, err)
 
 			balanceBefore, err := w.ERC20().BalanceOf(contractHex)
@@ -253,7 +254,7 @@ func TestScenario_ERC20(t *testing.T) {
 			assert.Nil(t, err)
 			otherWallet.Connect(alchemy.GetProvider())
 
-			_, err = otherWallet.ERC20().TransferFrom(contractHex, initAddress, otherAddress, transferAmount, nil)
+			_, err = otherWallet.ERC20().TransferFrom(context.Background(), contractHex, initAddress, otherAddress, transferAmount, nil)
 			assert.Nil(t, err)
 
 			balanceAfter, err := w.ERC20().BalanceOf(contractHex)
@@ -264,7 +265,7 @@ func TestScenario_ERC20(t *testing.T) {
 		t.Run("TransferFromNoWait: otherWallet transfers from initAddress, balance decreases after mined", func(t *testing.T) {
 			transferAmount := big.NewInt(30)
 
-			_, err := w.ERC20().Approve(contractHex, otherAddress, transferAmount, nil)
+			_, err := w.ERC20().Approve(context.Background(), contractHex, otherAddress, transferAmount, nil)
 			assert.Nil(t, err)
 
 			balanceBefore, err := w.ERC20().BalanceOf(contractHex)
@@ -278,7 +279,7 @@ func TestScenario_ERC20(t *testing.T) {
 			assert.Nil(t, err)
 			assert.NotEqual(t, txHash.Hex(), "0x0000000000000000000000000000000000000000000000000000000000000000")
 
-			_, err = alchemy.Transact.WaitMined(txHash.Hex())
+			_, err = alchemy.Transact.WaitMined(context.Background(), txHash.Hex())
 			assert.Nil(t, err)
 
 			balanceAfter, err := w.ERC20().BalanceOf(contractHex)
@@ -321,7 +322,7 @@ func TestScenario_SendTransaction(t *testing.T) {
 		assert.Equal(t, txHash, tx.Hash())
 
 		// wait for transact finish
-		txReceipt, err := alchemy.Transact.WaitMined(txHash.Hex())
+		txReceipt, err := alchemy.Transact.WaitMined(context.Background(), txHash.Hex())
 		assert.Nil(t, err)
 		assert.Equal(t, txReceipt.TxHash.Hex(), txHash.Hex())
 

--- a/ether/ether.go
+++ b/ether/ether.go
@@ -761,14 +761,14 @@ func (ether *Ether) ContractTransact(auth *bind.TransactOpts, contract types.Con
 }
 
 // TODO: support backoff
-func (ether *Ether) WaitMined(txHash common.Hash) (*gethTypes.Receipt, error) {
+func (ether *Ether) WaitMined(ctx context.Context, txHash common.Hash) (*gethTypes.Receipt, error) {
 	err := ether.SetEthClient()
 	if err != nil {
 		return nil, err
 	}
 	defer ether.Close()
 
-	tx, err := bind.WaitMined(context.Background(), ether.client, txHash)
+	tx, err := bind.WaitMined(ctx, ether.client, txHash)
 	if err != nil {
 		return nil, err
 	}
@@ -776,14 +776,14 @@ func (ether *Ether) WaitMined(txHash common.Hash) (*gethTypes.Receipt, error) {
 	return tx, nil
 }
 
-func (ether *Ether) WaitDeployed(txHash common.Hash) (common.Address, error) {
+func (ether *Ether) WaitDeployed(ctx context.Context, txHash common.Hash) (common.Address, error) {
 	err := ether.SetEthClient()
 	if err != nil {
 		return common.Address{}, err
 	}
 	defer ether.Close()
 
-	address, err := bind.WaitDeployed(context.Background(), ether.client, txHash)
+	address, err := bind.WaitDeployed(ctx, ether.client, txHash)
 	if err != nil {
 		return common.Address{}, err
 	}

--- a/ether/ether_transact_test.go
+++ b/ether/ether_transact_test.go
@@ -139,11 +139,38 @@ func TestEther_WaitMined(t *testing.T) {
 		)
 
 		// Act
-		receipt, err := ether.WaitMined(txHash)
+		receipt, err := ether.WaitMined(context.Background(), txHash)
 
 		// Assert
 		assert.NoError(t, err)
 		assert.Equal(t, receipt, expectedReceipt)
+	})
+
+	t.Run("ctx cancelled, return context.Canceled error", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange
+		ether := newEtherApiForTest()
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Mock: block until ctx is done
+		patches.ApplyFunc(
+			bind.WaitMined,
+			func(ctx context.Context, b bind.DeployBackend, hash common.Hash) (*gethTypes.Receipt, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		)
+
+		cancel()
+
+		// Act
+		receipt, err := ether.WaitMined(ctx, txHash)
+
+		// Assert
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Nil(t, receipt)
 	})
 
 	t.Run("error case", func(t *testing.T) {
@@ -164,7 +191,7 @@ func TestEther_WaitMined(t *testing.T) {
 			)
 
 			// Act
-			receipt, err := ether.WaitMined(txHash)
+			receipt, err := ether.WaitMined(context.Background(), txHash)
 
 			// Assert
 			assert.Error(t, err)
@@ -187,7 +214,7 @@ func TestEther_WaitMined(t *testing.T) {
 			)
 
 			// Act
-			receipt, err := ether.WaitMined(txHash)
+			receipt, err := ether.WaitMined(context.Background(), txHash)
 
 			// Assert
 			assert.Error(t, err)
@@ -216,11 +243,38 @@ func TestEther_WaitDeployed(t *testing.T) {
 		)
 
 		// Act
-		address, err := ether.WaitDeployed(txHash)
+		address, err := ether.WaitDeployed(context.Background(), txHash)
 
 		// Assert
 		assert.NoError(t, err)
 		assert.Equal(t, address, expectedAddress)
+	})
+
+	t.Run("ctx cancelled, return context.Canceled error", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange
+		ether := newEtherApiForTest()
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Mock: block until ctx is done
+		patches.ApplyFunc(
+			bind.WaitDeployed,
+			func(ctx context.Context, b bind.DeployBackend, hash common.Hash) (common.Address, error) {
+				<-ctx.Done()
+				return common.Address{}, ctx.Err()
+			},
+		)
+
+		cancel()
+
+		// Act
+		address, err := ether.WaitDeployed(ctx, txHash)
+
+		// Assert
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, address, common.Address{})
 	})
 
 	t.Run("error case", func(t *testing.T) {
@@ -241,7 +295,7 @@ func TestEther_WaitDeployed(t *testing.T) {
 			)
 
 			// Act
-			address, err := ether.WaitDeployed(txHash)
+			address, err := ether.WaitDeployed(context.Background(), txHash)
 
 			// Assert
 			assert.Error(t, err)
@@ -264,7 +318,7 @@ func TestEther_WaitDeployed(t *testing.T) {
 			)
 
 			// Act
-			address, err := ether.WaitDeployed(txHash)
+			address, err := ether.WaitDeployed(context.Background(), txHash)
 
 			// Assert
 			assert.Error(t, err)

--- a/namespace/transact_namespace.go
+++ b/namespace/transact_namespace.go
@@ -1,6 +1,8 @@
 package namespace
 
 import (
+	"context"
+
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/poteto-go/go-alchemy-sdk/types"
@@ -12,14 +14,14 @@ type ITransact interface {
 		returns the transaction receipt when it is mined.
 		It stops waiting when ctx is canceled.
 	*/
-	WaitMined(txHash string) (*gethTypes.Receipt, error)
+	WaitMined(ctx context.Context, txHash string) (*gethTypes.Receipt, error)
 
 	/*
 		WaitDeployed waits for a contract deployment transaction with the provided hash and
-		returns the contract address
+		returns the contract address.
 		It stops waiting when ctx is canceled.
 	*/
-	WaitDeployed(txHash string) (common.Address, error)
+	WaitDeployed(ctx context.Context, txHash string) (common.Address, error)
 }
 
 type Transact struct {
@@ -32,8 +34,8 @@ func NewTransactNamespace(ether types.EtherApi) ITransact {
 	}
 }
 
-func (t *Transact) WaitMined(txHash string) (*gethTypes.Receipt, error) {
-	txReceipt, err := t.ether.WaitMined(common.HexToHash(txHash))
+func (t *Transact) WaitMined(ctx context.Context, txHash string) (*gethTypes.Receipt, error) {
+	txReceipt, err := t.ether.WaitMined(ctx, common.HexToHash(txHash))
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +43,8 @@ func (t *Transact) WaitMined(txHash string) (*gethTypes.Receipt, error) {
 	return txReceipt, nil
 }
 
-func (t *Transact) WaitDeployed(txHash string) (common.Address, error) {
-	address, err := t.ether.WaitDeployed(common.HexToHash(txHash))
+func (t *Transact) WaitDeployed(ctx context.Context, txHash string) (common.Address, error) {
+	address, err := t.ether.WaitDeployed(ctx, common.HexToHash(txHash))
 	if err != nil {
 		return common.Address{}, err
 	}

--- a/namespace/transact_namespace_test.go
+++ b/namespace/transact_namespace_test.go
@@ -1,6 +1,7 @@
 package namespace_test
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -41,14 +42,14 @@ func Test_WaitMined(t *testing.T) {
 		patches.ApplyMethod(
 			reflect.TypeOf(api),
 			"WaitMined",
-			func(_ *ether.Ether, txHash common.Hash) (*gethTypes.Receipt, error) {
+			func(_ *ether.Ether, ctx context.Context, txHash common.Hash) (*gethTypes.Receipt, error) {
 				assert.Equal(t, txHash, hash)
 				return &gethTypes.Receipt{}, nil
 			},
 		)
 
 		// Act
-		_, err := transact.WaitMined(hexHash)
+		_, err := transact.WaitMined(context.Background(), hexHash)
 
 		// Assert
 		assert.NoError(t, err)
@@ -67,14 +68,14 @@ func Test_WaitMined(t *testing.T) {
 		patches.ApplyMethod(
 			reflect.TypeOf(api),
 			"WaitMined",
-			func(_ *ether.Ether, txHash common.Hash) (*gethTypes.Receipt, error) {
+			func(_ *ether.Ether, ctx context.Context, txHash common.Hash) (*gethTypes.Receipt, error) {
 				assert.Equal(t, txHash, hash)
 				return &gethTypes.Receipt{}, expectedErr
 			},
 		)
 
 		// Act
-		_, err := transact.WaitMined(hexHash)
+		_, err := transact.WaitMined(context.Background(), hexHash)
 
 		// Assert
 		assert.ErrorIs(t, err, expectedErr)
@@ -98,14 +99,14 @@ func Test_WaitDeployed(t *testing.T) {
 		patches.ApplyMethod(
 			reflect.TypeOf(api),
 			"WaitDeployed",
-			func(_ *ether.Ether, txHash common.Hash) (common.Address, error) {
+			func(_ *ether.Ether, ctx context.Context, txHash common.Hash) (common.Address, error) {
 				assert.Equal(t, txHash, hash)
 				return common.Address{}, nil
 			},
 		)
 
 		// Act
-		_, err := transact.WaitDeployed(hexHash)
+		_, err := transact.WaitDeployed(context.Background(), hexHash)
 
 		// Assert
 		assert.NoError(t, err)
@@ -124,14 +125,14 @@ func Test_WaitDeployed(t *testing.T) {
 		patches.ApplyMethod(
 			reflect.TypeOf(api),
 			"WaitDeployed",
-			func(_ *ether.Ether, txHash common.Hash) (common.Address, error) {
+			func(_ *ether.Ether, ctx context.Context, txHash common.Hash) (common.Address, error) {
 				assert.Equal(t, txHash, hash)
 				return common.Address{}, expectedErr
 			},
 		)
 
 		// Act
-		_, err := transact.WaitDeployed(hexHash)
+		_, err := transact.WaitDeployed(context.Background(), hexHash)
 
 		// Assert
 		assert.ErrorIs(t, err, expectedErr)

--- a/types/ether_api.go
+++ b/types/ether_api.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"context"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -205,14 +206,14 @@ type EtherApi interface {
 		returns the transaction receipt when it is mined.
 		It stops waiting when ctx is canceled.
 	*/
-	WaitMined(hash common.Hash) (*gethTypes.Receipt, error)
+	WaitMined(ctx context.Context, hash common.Hash) (*gethTypes.Receipt, error)
 
 	/*
 		WaitDeployed waits for a contract deployment transaction with the provided hash and
-		returns the contract address
+		returns the contract address.
 		It stops waiting when ctx is canceled.
 	*/
-	WaitDeployed(hash common.Hash) (common.Address, error)
+	WaitDeployed(ctx context.Context, hash common.Hash) (common.Address, error)
 
 	/*
 		ContractCall calls a contract.

--- a/wallet/erc20.go
+++ b/wallet/erc20.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"context"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -17,8 +18,9 @@ type WalletERC20 interface {
 		transfer erc20 token by provided wallet
 			- wait for mined
 			- gas limit is 300000 for default
+			- stops waiting when ctx is canceled
 	*/
-	Transfer(contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error)
+	Transfer(ctx context.Context, contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error)
 
 	/*
 		transfer erc20 token by provided wallet
@@ -30,8 +32,9 @@ type WalletERC20 interface {
 		transfer erc20 token from another address (requires prior approval)
 			- wait for mined
 			- gas limit is 300000 for default
+			- stops waiting when ctx is canceled
 	*/
-	TransferFrom(contractAddress, fromAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error)
+	TransferFrom(ctx context.Context, contractAddress, fromAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error)
 
 	/*
 		transfer erc20 token from another address (requires prior approval)
@@ -43,8 +46,9 @@ type WalletERC20 interface {
 		approve spender to spend erc20 token
 			- wait for mined
 			- gas limit is 300000 for default
+			- stops waiting when ctx is canceled
 	*/
-	Approve(contractAddress, spenderAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error)
+	Approve(ctx context.Context, contractAddress, spenderAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error)
 
 	/*
 		approve spender to spend erc20 token
@@ -87,23 +91,22 @@ type walletERC20 struct {
 	w *wallet
 }
 
-func (api *walletERC20) Transfer(contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
+func (api *walletERC20) waitMined(ctx context.Context, send func() (common.Hash, error)) (*gethTypes.Receipt, error) {
 	provider := api.w.snapshot()
 	if provider == nil {
 		return nil, constant.ErrWalletIsNotConnected
 	}
-
-	txHash, err := api.TransferNoWait(
-		contractAddress,
-		toAddress,
-		amount,
-		gasLimit,
-	)
+	txHash, err := send()
 	if err != nil {
 		return nil, err
 	}
+	return provider.Eth().WaitMined(ctx, txHash)
+}
 
-	return provider.Eth().WaitMined(txHash)
+func (api *walletERC20) Transfer(ctx context.Context, contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
+	return api.waitMined(ctx, func() (common.Hash, error) {
+		return api.TransferNoWait(contractAddress, toAddress, amount, gasLimit)
+	})
 }
 
 func buildERC20TxData(signature []byte, params ...[]byte) ([]byte, error) {
@@ -184,18 +187,10 @@ func (api *walletERC20) ApproveNoWait(contractAddress, spenderAddress string, am
 	return api.w.SendTransaction(txRequest)
 }
 
-func (api *walletERC20) Approve(contractAddress, spenderAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
-	provider := api.w.snapshot()
-	if provider == nil {
-		return nil, constant.ErrWalletIsNotConnected
-	}
-
-	txHash, err := api.ApproveNoWait(contractAddress, spenderAddress, amount, gasLimit)
-	if err != nil {
-		return nil, err
-	}
-
-	return provider.Eth().WaitMined(txHash)
+func (api *walletERC20) Approve(ctx context.Context, contractAddress, spenderAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
+	return api.waitMined(ctx, func() (common.Hash, error) {
+		return api.ApproveNoWait(contractAddress, spenderAddress, amount, gasLimit)
+	})
 }
 
 func (api *walletERC20) TransferFromNoWait(contractAddress, fromAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
@@ -225,18 +220,10 @@ func (api *walletERC20) TransferFromNoWait(contractAddress, fromAddress, toAddre
 	return api.w.SendTransaction(txRequest)
 }
 
-func (api *walletERC20) TransferFrom(contractAddress, fromAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
-	provider := api.w.snapshot()
-	if provider == nil {
-		return nil, constant.ErrWalletIsNotConnected
-	}
-
-	txHash, err := api.TransferFromNoWait(contractAddress, fromAddress, toAddress, amount, gasLimit)
-	if err != nil {
-		return nil, err
-	}
-
-	return provider.Eth().WaitMined(txHash)
+func (api *walletERC20) TransferFrom(ctx context.Context, contractAddress, fromAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
+	return api.waitMined(ctx, func() (common.Hash, error) {
+		return api.TransferFromNoWait(contractAddress, fromAddress, toAddress, amount, gasLimit)
+	})
 }
 
 func (api *walletERC20) BalanceOf(contractAddress string) (*big.Int, error) {

--- a/wallet/erc20_test.go
+++ b/wallet/erc20_test.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"context"
 	"errors"
 	"math/big"
 	"reflect"
@@ -83,13 +84,14 @@ func TestWallet_ERC20Transfer(t *testing.T) {
 		patches.ApplyMethod(
 			reflect.TypeOf(w.provider.Eth()),
 			"WaitMined",
-			func(_ *ether.Ether, _ common.Hash) (*gethTypes.Receipt, error) {
+			func(_ *ether.Ether, _ context.Context, _ common.Hash) (*gethTypes.Receipt, error) {
 				return &gethTypes.Receipt{}, nil
 			},
 		)
 
 		// Act
 		_, err := w.ERC20().Transfer(
+			context.Background(),
 			contractAddress,
 			otherAddress,
 			big.NewInt(1),
@@ -118,6 +120,7 @@ func TestWallet_ERC20Transfer(t *testing.T) {
 
 		// Act
 		_, err := w.ERC20().Transfer(
+			context.Background(),
 			contractAddress,
 			otherAddress,
 			big.NewInt(1),
@@ -134,6 +137,7 @@ func TestWallet_ERC20Transfer(t *testing.T) {
 
 		// Act
 		_, err := w.ERC20().Transfer(
+			context.Background(),
 			contractAddress,
 			otherAddress,
 			big.NewInt(1),
@@ -195,12 +199,14 @@ func TestWallet_ERC20TransferNoWait(t *testing.T) {
 			},
 		)
 
+		gasLimit := uint64(1)
+
 		// Act
 		txHash, err := w.ERC20().TransferNoWait(
 			contractAddress,
 			otherAddress,
 			big.NewInt(1),
-			new(uint64(1)),
+			&gasLimit,
 		)
 
 		// Assert
@@ -242,6 +248,7 @@ func TestWallet_ERC20TransferNoWait(t *testing.T) {
 
 		// Act
 		_, err := w.ERC20().Transfer(
+			context.Background(),
 			contractAddress,
 			otherAddress,
 			big.NewInt(1),
@@ -274,12 +281,12 @@ func TestWallet_ERC20Approve(t *testing.T) {
 		patches.ApplyMethod(
 			reflect.TypeOf(w.provider.Eth()),
 			"WaitMined",
-			func(_ *ether.Ether, _ common.Hash) (*gethTypes.Receipt, error) {
+			func(_ *ether.Ether, _ context.Context, _ common.Hash) (*gethTypes.Receipt, error) {
 				return &gethTypes.Receipt{}, nil
 			},
 		)
 
-		_, err := w.ERC20().Approve(contractAddress, spenderAddress, big.NewInt(1), nil)
+		_, err := w.ERC20().Approve(context.Background(), contractAddress, spenderAddress, big.NewInt(1), nil)
 
 		assert.Nil(t, err)
 	})
@@ -298,7 +305,7 @@ func TestWallet_ERC20Approve(t *testing.T) {
 			},
 		)
 
-		_, err := w.ERC20().Approve(contractAddress, spenderAddress, big.NewInt(1), nil)
+		_, err := w.ERC20().Approve(context.Background(), contractAddress, spenderAddress, big.NewInt(1), nil)
 
 		assert.Error(t, err)
 	})
@@ -306,7 +313,7 @@ func TestWallet_ERC20Approve(t *testing.T) {
 	t.Run("error w/o connect wallet", func(t *testing.T) {
 		w, _ := New(testPrivHex)
 
-		_, err := w.ERC20().Approve(contractAddress, spenderAddress, big.NewInt(1), nil)
+		_, err := w.ERC20().Approve(context.Background(), contractAddress, spenderAddress, big.NewInt(1), nil)
 
 		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
 	})
@@ -389,12 +396,12 @@ func TestWallet_ERC20TransferFrom(t *testing.T) {
 		patches.ApplyMethod(
 			reflect.TypeOf(w.provider.Eth()),
 			"WaitMined",
-			func(_ *ether.Ether, _ common.Hash) (*gethTypes.Receipt, error) {
+			func(_ *ether.Ether, _ context.Context, _ common.Hash) (*gethTypes.Receipt, error) {
 				return &gethTypes.Receipt{}, nil
 			},
 		)
 
-		_, err := w.ERC20().TransferFrom(contractAddress, fromAddress, toAddress, big.NewInt(1), nil)
+		_, err := w.ERC20().TransferFrom(context.Background(), contractAddress, fromAddress, toAddress, big.NewInt(1), nil)
 
 		assert.Nil(t, err)
 	})
@@ -413,7 +420,7 @@ func TestWallet_ERC20TransferFrom(t *testing.T) {
 			},
 		)
 
-		_, err := w.ERC20().TransferFrom(contractAddress, fromAddress, toAddress, big.NewInt(1), nil)
+		_, err := w.ERC20().TransferFrom(context.Background(), contractAddress, fromAddress, toAddress, big.NewInt(1), nil)
 
 		assert.Error(t, err)
 	})
@@ -421,7 +428,7 @@ func TestWallet_ERC20TransferFrom(t *testing.T) {
 	t.Run("error w/o connect wallet", func(t *testing.T) {
 		w, _ := New(testPrivHex)
 
-		_, err := w.ERC20().TransferFrom(contractAddress, fromAddress, toAddress, big.NewInt(1), nil)
+		_, err := w.ERC20().TransferFrom(context.Background(), contractAddress, fromAddress, toAddress, big.NewInt(1), nil)
 
 		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
 	})

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
@@ -58,8 +59,9 @@ type Wallet interface {
 		or an error if the creation failed.
 
 		It does not work on non-Ethernet compatible networks.
+		The operation stops waiting when ctx is canceled.
 	*/
-	DeployContract(metaData *bind.MetaData) (common.Address, error)
+	DeployContract(ctx context.Context, metaData *bind.MetaData) (common.Address, error)
 
 	/*
 		transact of Deployment Contract to tx pool.
@@ -75,8 +77,10 @@ type Wallet interface {
 	/*
 		ContractTransact executes a transaction on a deployed contract.
 		It waits for the transaction to be mined and returns the transaction receipt.
+		The operation stops waiting when ctx is canceled.
 	*/
 	ContractTransact(
+		ctx context.Context,
 		contract types.ContractInstance,
 		contractAddress string,
 		data []byte,
@@ -275,7 +279,7 @@ func (w *wallet) SendTransaction(txRequest types.TransactionRequest) (common.Has
 	return signedTx.Hash(), nil
 }
 
-func (w *wallet) DeployContract(metaData *bind.MetaData) (common.Address, error) {
+func (w *wallet) DeployContract(ctx context.Context, metaData *bind.MetaData) (common.Address, error) {
 	provider := w.snapshot()
 	if provider == nil {
 		return common.Address{}, constant.ErrWalletIsNotConnected
@@ -287,8 +291,7 @@ func (w *wallet) DeployContract(metaData *bind.MetaData) (common.Address, error)
 	}
 
 	tx := deployRes.Txs[metaData.ID]
-	// wait for deployment on chain
-	address, err := provider.Eth().WaitDeployed(tx.Hash())
+	address, err := provider.Eth().WaitDeployed(ctx, tx.Hash())
 	if err != nil {
 		return common.Address{}, err
 	}
@@ -315,6 +318,7 @@ func (w *wallet) DeployContractNoWait(metaData *bind.MetaData) (*bind.Deployment
 }
 
 func (w *wallet) ContractTransact(
+	ctx context.Context,
 	contract types.ContractInstance,
 	contractAddress string,
 	data []byte,
@@ -333,7 +337,7 @@ func (w *wallet) ContractTransact(
 		return nil, err
 	}
 
-	return provider.Eth().WaitMined(tx.Hash())
+	return provider.Eth().WaitMined(ctx, tx.Hash())
 }
 
 func (w *wallet) ContractTransactNoWait(

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"errors"
 	"math/big"
@@ -731,6 +732,7 @@ func TestWallet_DeployContract(t *testing.T) {
 			"WaitDeployed",
 			func(
 				_ *ether.Ether,
+				_ context.Context,
 				_ common.Hash,
 			) (common.Address, error) {
 				return expectedAddr, nil
@@ -738,7 +740,7 @@ func TestWallet_DeployContract(t *testing.T) {
 		)
 
 		// Act
-		addr, err := w.DeployContract(&metaData)
+		addr, err := w.DeployContract(context.Background(), &metaData)
 
 		// Assert
 		assert.Nil(t, err)
@@ -771,6 +773,7 @@ func TestWallet_DeployContract(t *testing.T) {
 			"WaitDeployed",
 			func(
 				_ *ether.Ether,
+				_ context.Context,
 				_ common.Hash,
 			) (common.Address, error) {
 				return common.Address{}, errors.New("error")
@@ -778,7 +781,7 @@ func TestWallet_DeployContract(t *testing.T) {
 		)
 
 		// Act
-		_, err := w.DeployContract(&metaData)
+		_, err := w.DeployContract(context.Background(), &metaData)
 
 		// Assert
 		assert.Error(t, err)
@@ -788,7 +791,7 @@ func TestWallet_DeployContract(t *testing.T) {
 		w, _ := New(testPrivHex)
 
 		// Act
-		_, err := w.DeployContract(&metaData)
+		_, err := w.DeployContract(context.Background(), &metaData)
 
 		// Assert
 		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
@@ -818,7 +821,7 @@ func TestWallet_DeployContract(t *testing.T) {
 		)
 
 		// Act
-		_, err := w.DeployContract(&metaData)
+		_, err := w.DeployContract(context.Background(), &metaData)
 
 		// Assert
 		assert.Error(t, err)
@@ -1067,13 +1070,13 @@ func TestWallet_ContractTransact(t *testing.T) {
 		patches.ApplyMethod(
 			reflect.TypeOf(w.provider.Eth()),
 			"WaitMined",
-			func(_ *ether.Ether, _ common.Hash) (*gethTypes.Receipt, error) {
+			func(_ *ether.Ether, _ context.Context, _ common.Hash) (*gethTypes.Receipt, error) {
 				return expectedReceipt, nil
 			},
 		)
 
 		// Act
-		txReceipt, err := w.ContractTransact(contract, contractAddress, data)
+		txReceipt, err := w.ContractTransact(context.Background(), contract, contractAddress, data)
 
 		//Assert
 		assert.Nil(t, err)
@@ -1084,7 +1087,7 @@ func TestWallet_ContractTransact(t *testing.T) {
 		w, _ := New(testPrivHex)
 
 		// Act
-		_, err := w.ContractTransact(contract, contractAddress, data)
+		_, err := w.ContractTransact(context.Background(), contract, contractAddress, data)
 
 		// Assert
 		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
@@ -1119,7 +1122,7 @@ func TestWallet_ContractTransact(t *testing.T) {
 		)
 
 		// Act
-		_, err := w.ContractTransact(contract, contractAddress, data)
+		_, err := w.ContractTransact(context.Background(), contract, contractAddress, data)
 
 		//Assert
 		assert.Error(t, err)
@@ -1164,13 +1167,13 @@ func TestWallet_ContractTransact(t *testing.T) {
 		patches.ApplyMethod(
 			reflect.TypeOf(w.provider.Eth()),
 			"WaitMined",
-			func(_ *ether.Ether, _ common.Hash) (*gethTypes.Receipt, error) {
+			func(_ *ether.Ether, _ context.Context, _ common.Hash) (*gethTypes.Receipt, error) {
 				return nil, errors.New("error")
 			},
 		)
 
 		// Act
-		_, err := w.ContractTransact(contract, contractAddress, data)
+		_, err := w.ContractTransact(context.Background(), contract, contractAddress, data)
 
 		// Assert
 		assert.Error(t, err)


### PR DESCRIPTION
## Summary

- Add `context.Context` as first parameter to `WaitMined` / `WaitDeployed` across all 4 layers (ether → types interface → namespace → wallet public API)
- 5 waiting wallet methods updated: `DeployContract`, `ContractTransact`, `Transfer`, `Approve`, `TransferFrom`
- `*NoWait` variants and read-only methods are out of scope
- Adds ctx-cancellation tests verifying `context.Canceled` is returned when ctx is cancelled mid-wait

Closes #321
Related: #357 (WaitingTimeout as future opt-in safety net)

## Test plan

- [ ] `go test ./ether/... ./namespace/... ./wallet/... -gcflags=all=-l` — all pass
- [ ] New test cases: `ctx cancelled, return context.Canceled error` for both `WaitMined` and `WaitDeployed`
- [ ] e2e: `just ci-e2e <PORT>` (scenario_test.go updated with `context.Background()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)