### PR TITLE
fix: getOrCreateAuth caches stale TransactOpts across transactions (#333)

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -130,8 +130,9 @@ type wallet struct {
 	provider   types.IAlchemyProvider
 	mu         sync.RWMutex
 
-	// Cache for performance (chainID is immutable for a given network)
+	// Cache for performance (chainID and legacy-chain flag are immutable per network)
 	cachedChainID *big.Int
+	legacyChain   bool
 
 	// for ERC20
 	erc20 namespace.IERC20
@@ -313,7 +314,7 @@ func (w *wallet) DeployContractNoWait(metaData *bind.MetaData) (*bind.Deployment
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
-	auth, err := w.getOrCreateAuth()
+	auth, err := w.buildAuth()
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +360,7 @@ func (w *wallet) ContractTransactNoWait(
 		return nil, constant.ErrWalletIsNotConnected
 	}
 
-	auth, err := w.getOrCreateAuth()
+	auth, err := w.buildAuth()
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +393,7 @@ func (w *wallet) ERC20() WalletERC20 {
 	return &walletERC20{w: w}
 }
 
-func (w *wallet) getOrCreateAuth() (*bind.TransactOpts, error) {
+func (w *wallet) buildAuth() (*bind.TransactOpts, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -402,12 +403,12 @@ func (w *wallet) getOrCreateAuth() (*bind.TransactOpts, error) {
 			return nil, err
 		}
 		w.cachedChainID = chainID
+		w.legacyChain = slices.Contains(internal.ChainListNotSupportEIP1559, chainID.Int64())
 	}
 
 	auth := bind.NewKeyedTransactor(w.privateKey, w.cachedChainID)
 
-	// for chain not support `EIP-1559`
-	if slices.Contains(internal.ChainListNotSupportEIP1559, w.cachedChainID.Int64()) {
+	if w.legacyChain {
 		gasPrice, err := w.provider.Eth().SuggestGasPrice()
 		if err != nil {
 			return nil, err
@@ -423,4 +424,5 @@ func (w *wallet) ResetPool() {
 	defer w.mu.Unlock()
 
 	w.cachedChainID = nil
+	w.legacyChain = false
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -130,9 +130,8 @@ type wallet struct {
 	provider   types.IAlchemyProvider
 	mu         sync.RWMutex
 
-	// Cache for performance
+	// Cache for performance (chainID is immutable for a given network)
 	cachedChainID *big.Int
-	cachedAuth    *bind.TransactOpts
 
 	// for ERC20
 	erc20 namespace.IERC20
@@ -397,27 +396,26 @@ func (w *wallet) getOrCreateAuth() (*bind.TransactOpts, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	if w.cachedAuth != nil {
-		return w.cachedAuth, nil
+	if w.cachedChainID == nil {
+		chainID, err := w.provider.Eth().ChainID()
+		if err != nil {
+			return nil, err
+		}
+		w.cachedChainID = chainID
 	}
-	chainID, err := w.provider.Eth().ChainID()
-	if err != nil {
-		return nil, err
-	}
-	w.cachedChainID = chainID
 
-	w.cachedAuth = bind.NewKeyedTransactor(w.privateKey, chainID)
+	auth := bind.NewKeyedTransactor(w.privateKey, w.cachedChainID)
 
 	// for chain not support `EIP-1559`
-	if slices.Contains(internal.ChainListNotSupportEIP1559, chainID.Int64()) {
+	if slices.Contains(internal.ChainListNotSupportEIP1559, w.cachedChainID.Int64()) {
 		gasPrice, err := w.provider.Eth().SuggestGasPrice()
 		if err != nil {
 			return nil, err
 		}
-		w.cachedAuth.GasPrice = gasPrice
-		return w.cachedAuth, nil
+		auth.GasPrice = gasPrice
 	}
-	return w.cachedAuth, nil
+
+	return auth, nil
 }
 
 func (w *wallet) ResetPool() {
@@ -425,5 +423,4 @@ func (w *wallet) ResetPool() {
 	defer w.mu.Unlock()
 
 	w.cachedChainID = nil
-	w.cachedAuth = nil
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1601,6 +1601,86 @@ func TestWallet_ContractCall(t *testing.T) {
 	})
 }
 
+func TestWallet_getOrCreateAuth(t *testing.T) {
+	t.Run("returns fresh TransactOpts each call so mutations do not bleed across calls", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"ChainID",
+			func(_ *ether.Ether) (*big.Int, error) {
+				return big.NewInt(1), nil
+			},
+		)
+
+		auth1, err := w.getOrCreateAuth()
+		assert.NoError(t, err)
+
+		// Simulate go-ethereum mutating the nonce field after sending a tx
+		auth1.Nonce = big.NewInt(42)
+
+		auth2, err := w.getOrCreateAuth()
+		assert.NoError(t, err)
+
+		assert.Nil(t, auth2.Nonce, "second call must return fresh TransactOpts without the stale Nonce")
+		assert.NotSame(t, auth1, auth2, "each call must return a distinct TransactOpts pointer")
+	})
+
+	t.Run("refreshes GasPrice on every call for non-EIP1559 chains", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+		suggestCount := 0
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"ChainID",
+			func(_ *ether.Ether) (*big.Int, error) {
+				return big.NewInt(internal.ChainListNotSupportEIP1559[0]), nil
+			},
+		)
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"SuggestGasPrice",
+			func(_ *ether.Ether) (*big.Int, error) {
+				suggestCount++
+				return big.NewInt(1_000_000_000), nil
+			},
+		)
+
+		_, _ = w.getOrCreateAuth()
+		_, _ = w.getOrCreateAuth()
+
+		assert.Equal(t, 2, suggestCount, "SuggestGasPrice must be called on every getOrCreateAuth for non-EIP1559 chains")
+	})
+
+	t.Run("caches chainID so ChainID RPC is called only once across multiple calls", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+		chainIDCallCount := 0
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"ChainID",
+			func(_ *ether.Ether) (*big.Int, error) {
+				chainIDCallCount++
+				return big.NewInt(1), nil
+			},
+		)
+
+		_, _ = w.getOrCreateAuth()
+		_, _ = w.getOrCreateAuth()
+
+		assert.Equal(t, 1, chainIDCallCount, "ChainID RPC must be called only once (cached)")
+	})
+}
+
 func TestWallet_ResetPool(t *testing.T) {
 	txData := &gethTypes.AccessListTx{
 		To:       &common.Address{},
@@ -1666,7 +1746,7 @@ func TestWallet_ResetPool(t *testing.T) {
 		assert.Equal(t, 2, callCount, "ChainID should be called again after reset")
 	})
 
-	t.Run("clears both chainID and auth", func(t *testing.T) {
+	t.Run("clears cachedChainID", func(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
@@ -1701,13 +1781,11 @@ func TestWallet_ResetPool(t *testing.T) {
 		// Act - Create cache
 		_, _ = w.ContractTransactNoWait(contract, contractAddress, data)
 		assert.NotNil(t, w.cachedChainID, "ChainID should be cached")
-		assert.NotNil(t, w.cachedAuth, "Auth should be cached")
 
 		// Act - Reset
 		w.ResetPool()
 
 		// Assert
 		assert.Nil(t, w.cachedChainID, "ChainID should be cleared")
-		assert.Nil(t, w.cachedAuth, "Auth should be cleared")
 	})
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1601,28 +1601,29 @@ func TestWallet_ContractCall(t *testing.T) {
 	})
 }
 
-func TestWallet_getOrCreateAuth(t *testing.T) {
+func applyChainIDPatch(patches *gomonkey.Patches, w *wallet, id *big.Int) {
+	patches.ApplyMethod(
+		reflect.TypeOf(w.provider.Eth()),
+		"ChainID",
+		func(_ *ether.Ether) (*big.Int, error) { return id, nil },
+	)
+}
+
+func TestWallet_buildAuth(t *testing.T) {
 	t.Run("returns fresh TransactOpts each call so mutations do not bleed across calls", func(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
 		w := createConnectedWallet()
+		applyChainIDPatch(patches, w, big.NewInt(1))
 
-		patches.ApplyMethod(
-			reflect.TypeOf(w.provider.Eth()),
-			"ChainID",
-			func(_ *ether.Ether) (*big.Int, error) {
-				return big.NewInt(1), nil
-			},
-		)
-
-		auth1, err := w.getOrCreateAuth()
+		auth1, err := w.buildAuth()
 		assert.NoError(t, err)
 
 		// Simulate go-ethereum mutating the nonce field after sending a tx
 		auth1.Nonce = big.NewInt(42)
 
-		auth2, err := w.getOrCreateAuth()
+		auth2, err := w.buildAuth()
 		assert.NoError(t, err)
 
 		assert.Nil(t, auth2.Nonce, "second call must return fresh TransactOpts without the stale Nonce")
@@ -1636,13 +1637,7 @@ func TestWallet_getOrCreateAuth(t *testing.T) {
 		w := createConnectedWallet()
 		suggestCount := 0
 
-		patches.ApplyMethod(
-			reflect.TypeOf(w.provider.Eth()),
-			"ChainID",
-			func(_ *ether.Ether) (*big.Int, error) {
-				return big.NewInt(internal.ChainListNotSupportEIP1559[0]), nil
-			},
-		)
+		applyChainIDPatch(patches, w, big.NewInt(internal.ChainListNotSupportEIP1559[0]))
 		patches.ApplyMethod(
 			reflect.TypeOf(w.provider.Eth()),
 			"SuggestGasPrice",
@@ -1652,10 +1647,10 @@ func TestWallet_getOrCreateAuth(t *testing.T) {
 			},
 		)
 
-		_, _ = w.getOrCreateAuth()
-		_, _ = w.getOrCreateAuth()
+		_, _ = w.buildAuth()
+		_, _ = w.buildAuth()
 
-		assert.Equal(t, 2, suggestCount, "SuggestGasPrice must be called on every getOrCreateAuth for non-EIP1559 chains")
+		assert.Equal(t, 2, suggestCount, "SuggestGasPrice must be called on every buildAuth for non-EIP1559 chains")
 	})
 
 	t.Run("caches chainID so ChainID RPC is called only once across multiple calls", func(t *testing.T) {
@@ -1674,8 +1669,8 @@ func TestWallet_getOrCreateAuth(t *testing.T) {
 			},
 		)
 
-		_, _ = w.getOrCreateAuth()
-		_, _ = w.getOrCreateAuth()
+		_, _ = w.buildAuth()
+		_, _ = w.buildAuth()
 
 		assert.Equal(t, 1, chainIDCallCount, "ChainID RPC must be called only once (cached)")
 	})


### PR DESCRIPTION
## Summary

- Removes `cachedAuth *bind.TransactOpts` from the `wallet` struct — `bind.TransactOpts` is mutable per-transaction state (Nonce, GasPrice, Context) and must never be reused across calls
- `getOrCreateAuth` now builds a **fresh** `bind.TransactOpts` on every call using the already-cached `chainID`
- For non-EIP-1559 chains, `SuggestGasPrice` is called on **every** `getOrCreateAuth` invocation so gas price stays current with the fee market
- `ResetPool` simplified — only clears `cachedChainID` (auth is no longer cached)

Fixes the three failure modes reported in #333:
1. Stale `Nonce` bleeding into the next transaction → `nonce too low`
2. Stale `GasPrice` captured once and never refreshed on legacy chains
3. Race condition on the shared `*TransactOpts` fields under concurrent calls

## Test plan

- [x] `TestWallet_getOrCreateAuth/returns_fresh_TransactOpts_each_call_so_mutations_do_not_bleed_across_calls` — verifies separate pointer and nil Nonce on second call
- [x] `TestWallet_getOrCreateAuth/refreshes_GasPrice_on_every_call_for_non-EIP1559_chains` — verifies `SuggestGasPrice` called twice across two `getOrCreateAuth` calls
- [x] `TestWallet_getOrCreateAuth/caches_chainID_so_ChainID_RPC_is_called_only_once_across_multiple_calls` — verifies chainID RPC is still cached
- [x] Full `wallet` package test suite: `go test ./wallet/... -gcflags=all=-l`

🤖 Generated with [Claude Code](https://claude.com/claude-code)