### PR TITLE
feat: Add WaitingTimeout to AlchemySetting as safety net for WaitMined/WaitDeployed

### DIFF
--- a/docs/docs/setting/alchemySetting.md
+++ b/docs/docs/setting/alchemySetting.md
@@ -113,3 +113,22 @@ The limit is enforced on **all** response paths:
 
 - **Alchemy JSON-RPC** (`AlchemyFetch` / `AlchemyBatchFetch`): returns `constant.ErrFailedToReadResponse` when the body exceeds the limit.
 - **geth `ethclient` methods** (e.g. `BlockNumber`, `CallContract`): the underlying `http.Client` uses a `limitedTransport` that wraps every response body with `io.LimitReader`, so oversized responses are also truncated here.
+
+### WaitMined / WaitDeployed Timeout
+
+`WaitingTimeout` sets a safety-net deadline for `WaitMined` and `WaitDeployed` so they never hang indefinitely. The default is **300 seconds**. Set to `0` to keep the default.
+
+```go
+func main() {
+	setting := gas.AlchemySetting{
+		ApiKey:  "<alchemy-api-key>",
+		Network: types.EthSepolia,
+		// Override to 60 seconds
+		WaitingTimeout: 60 * time.Second,
+	}
+
+	alchemy := gas.NewAlchemy(setting)
+}
+```
+
+The timeout composes with any per-call `context.Context` deadline — whichever fires first wins. Users who pass their own `ctx` with `context.WithTimeout` continue to get that behaviour unchanged.

--- a/ether/ether.go
+++ b/ether/ether.go
@@ -760,6 +760,13 @@ func (ether *Ether) ContractTransact(auth *bind.TransactOpts, contract types.Con
 	// return ether.WaitMined(tx.Hash())
 }
 
+func (ether *Ether) withWaitingTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ether.config.waitingTimeout > 0 {
+		return context.WithTimeout(ctx, ether.config.waitingTimeout)
+	}
+	return ctx, func() {}
+}
+
 // TODO: support backoff
 func (ether *Ether) WaitMined(ctx context.Context, txHash common.Hash) (*gethTypes.Receipt, error) {
 	err := ether.SetEthClient()
@@ -767,6 +774,9 @@ func (ether *Ether) WaitMined(ctx context.Context, txHash common.Hash) (*gethTyp
 		return nil, err
 	}
 	defer ether.Close()
+
+	ctx, cancel := ether.withWaitingTimeout(ctx)
+	defer cancel()
 
 	tx, err := bind.WaitMined(ctx, ether.client, txHash)
 	if err != nil {
@@ -782,6 +792,9 @@ func (ether *Ether) WaitDeployed(ctx context.Context, txHash common.Hash) (commo
 		return common.Address{}, err
 	}
 	defer ether.Close()
+
+	ctx, cancel := ether.withWaitingTimeout(ctx)
+	defer cancel()
 
 	address, err := bind.WaitDeployed(ctx, ether.client, txHash)
 	if err != nil {

--- a/ether/ether_config.go
+++ b/ether/ether_config.go
@@ -17,6 +17,7 @@ type EtherApiConfig struct {
 	customHeaders    []http.Header
 	jwtSecret        []byte
 	maxResponseBytes int64
+	waitingTimeout   time.Duration
 }
 
 func NewEtherApiConfig(
@@ -27,6 +28,7 @@ func NewEtherApiConfig(
 	customHeaders []http.Header,
 	jwtSecret []byte,
 	maxResponseBytes int64,
+	waitingTimeout time.Duration,
 ) EtherApiConfig {
 	return EtherApiConfig{
 		url:              url,
@@ -36,6 +38,7 @@ func NewEtherApiConfig(
 		customHeaders:    customHeaders,
 		jwtSecret:        jwtSecret,
 		maxResponseBytes: maxResponseBytes,
+		waitingTimeout:   waitingTimeout,
 	}
 }
 

--- a/ether/ether_config_test.go
+++ b/ether/ether_config_test.go
@@ -20,6 +20,7 @@ func TestNewEtherApiConfig(t *testing.T) {
 	customHeaders := []http.Header{
 		{"hello": []string{"world"}},
 	}
+	waitingTimeout := 300 * time.Second
 
 	// Act
 	config := NewEtherApiConfig(
@@ -30,6 +31,7 @@ func TestNewEtherApiConfig(t *testing.T) {
 		customHeaders,
 		[]byte(""),
 		0,
+		waitingTimeout,
 	)
 
 	// Assert
@@ -39,4 +41,5 @@ func TestNewEtherApiConfig(t *testing.T) {
 	assert.Equal(t, config.backoffConfig, &backoffConfig)
 	assert.Equal(t, config.customHeaders, customHeaders)
 	assert.Equal(t, int64(0), config.maxResponseBytes)
+	assert.Equal(t, waitingTimeout, config.waitingTimeout)
 }

--- a/ether/ether_core_test.go
+++ b/ether/ether_core_test.go
@@ -39,7 +39,7 @@ var utAlchemySetting = gas.AlchemySetting{
 	},
 }
 
-func newEtherApiForTest() *eth.Ether {
+func newEtherApiForTestWithTimeout(waitingTimeout time.Duration) *eth.Ether {
 	provider := newProviderForTest()
 	config, err := gas.NewAlchemyConfig(utAlchemySetting)
 	if err != nil {
@@ -56,8 +56,13 @@ func newEtherApiForTest() *eth.Ether {
 			[]http.Header{},
 			[]byte(""),
 			0,
+			waitingTimeout,
 		),
 	).(*eth.Ether)
+}
+
+func newEtherApiForTest() *eth.Ether {
+	return newEtherApiForTestWithTimeout(0)
 }
 
 func newNilEtherApiForTest(provider *gas.AlchemyProvider) *eth.Ether {
@@ -70,6 +75,7 @@ func newNilEtherApiForTest(provider *gas.AlchemyProvider) *eth.Ether {
 			nil,
 			[]http.Header{},
 			[]byte(""),
+			0,
 			0,
 		),
 	).(*eth.Ether)

--- a/ether/ether_secret_test.go
+++ b/ether/ether_secret_test.go
@@ -39,6 +39,7 @@ func newEtherApiWSecretForTest() *eth.Ether {
 			[]http.Header{},
 			decoded,
 			0,
+			0,
 		),
 	).(*eth.Ether)
 }
@@ -59,6 +60,7 @@ func newEtherApiWIvalidSecretForTest() *eth.Ether {
 			nil,
 			[]http.Header{},
 			[]byte("invalid"),
+			0,
 			0,
 		),
 	).(*eth.Ether)

--- a/ether/ether_transact_test.go
+++ b/ether/ether_transact_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"math/big"
 	"strings"
@@ -17,6 +18,10 @@ import (
 	eth "github.com/poteto-go/go-alchemy-sdk/ether"
 	"github.com/stretchr/testify/assert"
 )
+
+func newEtherApiWithWaitingTimeoutForTest(timeout time.Duration) *eth.Ether {
+	return newEtherApiForTestWithTimeout(timeout)
+}
 
 type mockContract struct {
 	abi abi.ABI
@@ -324,5 +329,59 @@ func TestEther_WaitDeployed(t *testing.T) {
 			assert.Error(t, err)
 			assert.Equal(t, address, common.Address{})
 		})
+	})
+}
+
+func TestEther_WaitMined_WithWaitingTimeout(t *testing.T) {
+	txHash := common.HexToHash("0x123")
+
+	t.Run("WaitingTimeout fires when bind.WaitMined blocks", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange: very short timeout so the test doesn't actually wait long
+		ether := newEtherApiWithWaitingTimeoutForTest(10 * time.Millisecond)
+
+		patches.ApplyFunc(
+			bind.WaitMined,
+			func(ctx context.Context, b bind.DeployBackend, hash common.Hash) (*gethTypes.Receipt, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		)
+
+		// Act
+		receipt, err := ether.WaitMined(context.Background(), txHash)
+
+		// Assert: context deadline exceeded from the waitingTimeout
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.Nil(t, receipt)
+	})
+}
+
+func TestEther_WaitDeployed_WithWaitingTimeout(t *testing.T) {
+	txHash := common.HexToHash("0x123")
+
+	t.Run("WaitingTimeout fires when bind.WaitDeployed blocks", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange: very short timeout so the test doesn't actually wait long
+		ether := newEtherApiWithWaitingTimeoutForTest(10 * time.Millisecond)
+
+		patches.ApplyFunc(
+			bind.WaitDeployed,
+			func(ctx context.Context, b bind.DeployBackend, hash common.Hash) (common.Address, error) {
+				<-ctx.Done()
+				return common.Address{}, ctx.Err()
+			},
+		)
+
+		// Act
+		address, err := ether.WaitDeployed(context.Background(), txHash)
+
+		// Assert: context deadline exceeded from the waitingTimeout
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.Equal(t, address, common.Address{})
 	})
 }

--- a/ether/ether_whitebox_test.go
+++ b/ether/ether_whitebox_test.go
@@ -12,7 +12,7 @@ import (
 // SetEthClient does not permanently inflate connCount (issue #324).
 func TestEther_SetEthClient_ConnCountRollbackOnError(t *testing.T) {
 	e := &Ether{
-		config: NewEtherApiConfig("", 0, time.Duration(0), nil, nil, []byte(""), 0),
+		config: NewEtherApiConfig("", 0, time.Duration(0), nil, nil, []byte(""), 0, 0),
 		mu:     &sync.Mutex{},
 	}
 

--- a/gas/alchemy_config.go
+++ b/gas/alchemy_config.go
@@ -23,6 +23,7 @@ type AlchemyConfig struct {
 	customHeaders        []http.Header
 	jwtSecret            []byte
 	maxResponseBytes     int64
+	waitingTimeout       time.Duration
 }
 
 func NewAlchemyConfig(setting AlchemySetting) (AlchemyConfig, error) {
@@ -47,6 +48,7 @@ func NewAlchemyConfig(setting AlchemySetting) (AlchemyConfig, error) {
 		customHeaders:        setting.CustomHeaders,
 		jwtSecret:            decodedJwt,
 		maxResponseBytes:     setting.MaxResponseBytes,
+		waitingTimeout:       setting.WaitingTimeout,
 	}
 
 	if config.requestTimeout == 0 {
@@ -59,6 +61,10 @@ func NewAlchemyConfig(setting AlchemySetting) (AlchemyConfig, error) {
 
 	if config.maxResponseBytes == 0 {
 		config.maxResponseBytes = types.DefaultMaxResponseBytes
+	}
+
+	if config.waitingTimeout == 0 {
+		config.waitingTimeout = 300 * time.Second
 	}
 
 	return config, nil
@@ -106,5 +112,6 @@ func (config *AlchemyConfig) toEtherApiConfig() ether.EtherApiConfig {
 		config.customHeaders,
 		config.jwtSecret,
 		config.maxResponseBytes,
+		config.waitingTimeout,
 	)
 }

--- a/gas/alchemy_config_test.go
+++ b/gas/alchemy_config_test.go
@@ -2,6 +2,7 @@ package gas
 
 import (
 	"testing"
+	"time"
 
 	"github.com/poteto-go/go-alchemy-sdk/ether"
 	"github.com/poteto-go/go-alchemy-sdk/types"
@@ -145,4 +146,27 @@ func TestAlchemyConfig_toEtherApiConfig(t *testing.T) {
 
 	// Assert
 	assert.IsType(t, etherConfig, ether.EtherApiConfig{})
+}
+
+func TestNewAlchemyConfig_WaitingTimeout(t *testing.T) {
+	t.Run("defaults to 300s when not set", func(t *testing.T) {
+		config, err := NewAlchemyConfig(AlchemySetting{
+			ApiKey:  "api-key",
+			Network: types.MaticMainnet,
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 300*time.Second, config.waitingTimeout)
+	})
+
+	t.Run("uses configured value when set", func(t *testing.T) {
+		config, err := NewAlchemyConfig(AlchemySetting{
+			ApiKey:         "api-key",
+			Network:        types.MaticMainnet,
+			WaitingTimeout: 60 * time.Second,
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 60*time.Second, config.waitingTimeout)
+	})
 }

--- a/gas/alchemy_setting.go
+++ b/gas/alchemy_setting.go
@@ -37,6 +37,10 @@ type AlchemySetting struct {
 	// Set to 0 to use the default.
 	MaxResponseBytes int64 `yaml:"max_response_bytes"`
 
+	// Safety-net timeout for WaitMined/WaitDeployed (default: 300s).
+	// Set to 0 to use the default. Composes with per-call ctx deadlines.
+	WaitingTimeout time.Duration `yaml:"waiting_timeout"`
+
 	/*
 		return true => p8net is selected
 

--- a/namespace/core_namespace_test.go
+++ b/namespace/core_namespace_test.go
@@ -41,6 +41,7 @@ func newEtherApi() *ether.Ether {
 		[]http.Header{},
 		nil,
 		0,
+		0,
 	)).(*ether.Ether)
 }
 


### PR DESCRIPTION
## Summary

closes #357

- Adds `WaitingTimeout time.Duration` to `AlchemySetting` (default **300 s** when unset, matching the same defaulting pattern as `RequestTimeout`)
- Threads `waitingTimeout` through `AlchemyConfig` → `EtherApiConfig`
- `WaitMined` and `WaitDeployed` compose the timeout with the caller-supplied `ctx` via a private `withWaitingTimeout` helper — whichever deadline fires first wins
- Updates `docs/docs/setting/alchemySetting.md` with usage example

## Behaviour

| Scenario | Result |
|---|---|
| `WaitingTimeout` not set | 300 s safety net applied automatically |
| `WaitingTimeout: 60*time.Second` | 60 s safety net |
| Caller passes `ctx` with 10 s deadline | 10 s wins (context composes) |
| `EtherApiConfig` constructed directly with `waitingTimeout: 0` | no timeout (guard respected) |

## Test plan

- [x] `TestNewAlchemyConfig_WaitingTimeout` — default 300 s and explicit value
- [x] `TestNewEtherApiConfig` — field round-trips through constructor
- [x] `TestEther_WaitMined_WithWaitingTimeout` — timeout fires when `bind.WaitMined` blocks
- [x] `TestEther_WaitDeployed_WithWaitingTimeout` — timeout fires when `bind.WaitDeployed` blocks
- [x] All existing tests pass (`just ut`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)