### PR TITLE
docs: add JWT secret section to AlchemySetting

### DIFF
--- a/docs/docs/setting/alchemySetting.md
+++ b/docs/docs/setting/alchemySetting.md
@@ -113,3 +113,30 @@ The limit is enforced on **all** response paths:
 
 - **Alchemy JSON-RPC** (`AlchemyFetch` / `AlchemyBatchFetch`): returns `constant.ErrFailedToReadResponse` when the body exceeds the limit.
 - **geth `ethclient` methods** (e.g. `BlockNumber`, `CallContract`): the underlying `http.Client` uses a `limitedTransport` that wraps every response body with `io.LimitReader`, so oversized responses are also truncated here.
+
+### JWT Secret (Engine API Authentication)
+
+geth's [Engine API](https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md) requires JWT authentication. Set `JwtSecret` in `PrivateNetworkConfig` to enable it.
+
+`JwtSecret` must be a **hex-encoded 64-character string** (32 raw bytes), matching the `--authrpc.jwtsecret` file used by your geth node.
+
+```go
+func main() {
+	setting := gas.AlchemySetting{
+		PrivateNetworkConfig: gas.PrivateNetworkConfig{
+			Host:      "127.0.0.1",
+			Port:      8551, // geth default Engine API port
+			JwtSecret: "bcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31",
+		},
+	}
+
+	alchemy := gas.NewAlchemy(setting)
+}
+```
+
+When `JwtSecret` is set the SDK:
+
+1. Signs a JWT (`HS256`, `iat` + `exp` claims) and sends it as `Authorization: Bearer <token>` on every request.
+2. Automatically recreates the underlying `ethclient` before the token expires — geth accepts tokens within a **60-second** `iat` window, and the SDK refreshes ~5 seconds early to absorb clock skew.
+
+If `JwtSecret` is omitted the `Authorization` header is not sent (suitable for unauthenticated HTTP endpoints).


### PR DESCRIPTION
## Summary

- Documents the `JwtSecret` field in `PrivateNetworkConfig` — the Engine API JWT authentication feature that was already implemented but not documented
- Explains the required format: 64-character hex string (32 raw bytes), matching geth's `--authrpc.jwtsecret` file
- Describes the SDK's automatic `ethclient` recreation before the 60-second `iat` window expires (~5 s safety margin)

## Test plan

- [ ] Verify the new section renders correctly in the Docusaurus docs site
- [ ] Confirm the code example matches the actual `PrivateNetworkConfig` struct fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)