### PR TITLE
feat: StableCoin namespace and wallet support

### DIFF
--- a/docs/docs/stablecoin-namespace/BalanceOf.md
+++ b/docs/docs/stablecoin-namespace/BalanceOf.md
@@ -1,0 +1,21 @@
+ref: [Wallet-StableCoin-BalanceOf](../wallet/StableCoin.md#balanceof)
+
+![](https://img.shields.io/badge/go-geth-lightblue)
+
+Get StableCoin token balance of the provided walletAddress.
+
+```go
+func BalanceOf(
+    contractAddress,
+    walletAddress string,
+) (balance *big.Int, err error)
+```
+
+```go
+func main() {
+    ...
+    alchemy := gas.NewAlchemy(setting)
+    ...
+    balance, err := alchemy.StableCoin.BalanceOf(contractAddress, walletAddress)
+}
+```

--- a/docs/docs/stablecoin-namespace/_category_.json
+++ b/docs/docs/stablecoin-namespace/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "StableCoin Namespace",
+  "position": 13
+}

--- a/docs/docs/wallet/StableCoin.md
+++ b/docs/docs/wallet/StableCoin.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 13
+---
+
+# StableCoin
+
+You can execute ERC20-compatible methods on StableCoin contracts (e.g. USDC) from the specified wallet.
+
+:::note
+
+Since it performs calls via bytecode, it does not require the contract implementation and can be called as long as the address is available.
+
+:::
+
+:::warning
+
+- It requires connected wallet.
+- It does not work on non-Ethereum compatible networks.
+
+:::
+
+```go
+func main() {
+	alchemy = gas.NewAlchemy(setting)
+	w, _ := wallet.New("<privateKey>")
+	w.Connect(alchemy.GetProvider())
+
+	// call each method
+	w.StableCoin().MethodXXX()
+}
+```
+
+## BalanceOf
+
+Get the StableCoin token balance of the connected wallet address.
+
+```go
+func BalanceOf(contractAddress string) (balance *big.Int, err error)
+```
+
+```go
+func main() {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	balance, err := w.StableCoin().BalanceOf(contractAddress)
+}
+```
+
+## Read Methods
+
+You can fetch token metadata and balance information:
+
+- TotalSupply
+- Allowance
+- Name
+- Symbol
+- Decimals
+- BalanceOf
+
+## Write Methods
+
+### Transfer & TransferNoWait
+
+Transfer StableCoin token from wallet.
+
+```go
+receipt, err := w.StableCoin().Transfer(
+	context.Background(),
+	contractAddress,
+	"<toAddress>",
+	big.NewInt(100),
+	nil,
+)
+```
+
+### Approve & ApproveNoWait
+
+Approve a spender to spend tokens on behalf of the connected wallet.
+
+```go
+receipt, err := w.StableCoin().Approve(
+	context.Background(),
+	contractAddress,
+	"<spenderAddress>",
+	big.NewInt(100),
+	nil,
+)
+```
+
+### TransferFrom & TransferFromNoWait
+
+Transfer tokens from another address using a prior allowance.
+
+```go
+receipt, err := w.StableCoin().TransferFrom(
+	context.Background(),
+	contractAddress,
+	"<fromAddress>",
+	"<toAddress>",
+	big.NewInt(100),
+	nil,
+)
+```

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -169,6 +169,53 @@ func TestSenario_DeployContract(t *testing.T) {
 	})
 }
 
+func TestScenario_StableCoin(t *testing.T) {
+	t.Run("1. can create wallet 2. connect wallet 3. can deploy erc20 contract as stablecoin", func(t *testing.T) {
+		w, err := wallet.New(initPrivateKey)
+
+		assert.Nil(t, err)
+
+		w.Connect(alchemy.GetProvider())
+
+		erc20Metadata := &artifacts.ERC20MetaData
+		deployer.BindDeploymentMetadata(erc20Metadata, big.NewInt(1000))
+		contractAddress, err := w.DeployContract(context.Background(), erc20Metadata)
+
+		assert.Nil(t, err)
+		assert.NotEqual(t, contractAddress, common.HexToAddress("0x0"))
+		contractHex := contractAddress.Hex()
+
+		t.Run("can get balance via StableCoin", func(t *testing.T) {
+			balance, err := w.StableCoin().BalanceOf(contractHex)
+
+			assert.Nil(t, err)
+			assert.Equal(t, balance.Cmp(big.NewInt(10)), 1)
+		})
+
+		t.Run("can get other info via StableCoin", func(t *testing.T) {
+			totalSupply, err := w.StableCoin().TotalSupply(contractHex)
+			assert.Nil(t, err)
+			assert.Equal(t, totalSupply.Cmp(big.NewInt(1000)), 0)
+
+			name, err := w.StableCoin().Name(contractHex)
+			assert.Nil(t, err)
+			assert.Equal(t, "Minimal Token", name)
+
+			symbol, err := w.StableCoin().Symbol(contractHex)
+			assert.Nil(t, err)
+			assert.Equal(t, "MTK", symbol)
+
+			decimals, err := w.StableCoin().Decimals(contractHex)
+			assert.Nil(t, err)
+			assert.Equal(t, uint8(18), decimals)
+
+			allowance, err := w.StableCoin().Allowance(contractHex, initAddress, otherAddress)
+			assert.Nil(t, err)
+			assert.Equal(t, allowance.Cmp(big.NewInt(0)), 0)
+		})
+	})
+}
+
 func TestScenario_ERC20(t *testing.T) {
 	t.Run("1. can create wallet 2. connect wallet 3. can deploy erc20 contract", func(t *testing.T) {
 		w, err := wallet.New(initPrivateKey)

--- a/gas/alchemy.go
+++ b/gas/alchemy.go
@@ -7,12 +7,13 @@ import (
 )
 
 type Alchemy struct {
-	config   AlchemyConfig
-	Core     namespace.ICore
-	Transact namespace.ITransact
-	Nft      namespace.INft
-	ERC20    namespace.IERC20
-	provider types.IAlchemyProvider
+	config     AlchemyConfig
+	Core       namespace.ICore
+	Transact   namespace.ITransact
+	Nft        namespace.INft
+	ERC20      namespace.IERC20
+	StableCoin namespace.IStableCoin
+	provider   types.IAlchemyProvider
 }
 
 func NewAlchemy(setting AlchemySetting) (Alchemy, error) {
@@ -31,14 +32,16 @@ func NewAlchemy(setting AlchemySetting) (Alchemy, error) {
 	transactNamespace := namespace.NewTransactNamespace(ether)
 	nftNamespace := namespace.NewNftNamespace(ether)
 	erc20Namespace := namespace.NewERC20Namespace(ether)
+	stableCoinNamespace := namespace.NewStableCoinNamespace(ether)
 
 	return Alchemy{
-		config:   alchemyConfig,
-		Core:     coreNamespace,
-		Transact: transactNamespace,
-		Nft:      nftNamespace,
-		ERC20:    erc20Namespace,
-		provider: alchemyProvider,
+		config:     alchemyConfig,
+		Core:       coreNamespace,
+		Transact:   transactNamespace,
+		Nft:        nftNamespace,
+		ERC20:      erc20Namespace,
+		StableCoin: stableCoinNamespace,
+		provider:   alchemyProvider,
 	}, nil
 }
 

--- a/namespace/stablecoin_namespace.go
+++ b/namespace/stablecoin_namespace.go
@@ -1,0 +1,15 @@
+package namespace
+
+import "github.com/poteto-go/go-alchemy-sdk/types"
+
+type IStableCoin interface {
+	IERC20
+}
+
+type stableCoin struct {
+	*ERC20
+}
+
+func NewStableCoinNamespace(ether types.EtherApi) IStableCoin {
+	return &stableCoin{ERC20: &ERC20{ether: ether}}
+}

--- a/namespace/stablecoin_namespace_test.go
+++ b/namespace/stablecoin_namespace_test.go
@@ -1,0 +1,16 @@
+package namespace_test
+
+import (
+	"testing"
+
+	"github.com/poteto-go/go-alchemy-sdk/namespace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewStableCoinNamespace(t *testing.T) {
+	eth := newEtherApi()
+
+	sc := namespace.NewStableCoinNamespace(eth)
+
+	assert.NotNil(t, sc)
+}

--- a/wallet/stablecoin.go
+++ b/wallet/stablecoin.go
@@ -1,0 +1,9 @@
+package wallet
+
+type WalletStableCoin interface {
+	WalletERC20
+}
+
+type walletStableCoin struct {
+	walletERC20
+}

--- a/wallet/stablecoin_test.go
+++ b/wallet/stablecoin_test.go
@@ -1,0 +1,17 @@
+package wallet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWallet_StableCoin(t *testing.T) {
+	t.Run("returns WalletStableCoin", func(t *testing.T) {
+		w := createConnectedWallet()
+
+		sc := w.StableCoin()
+
+		assert.NotNil(t, sc)
+	})
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -115,6 +115,9 @@ type Wallet interface {
 	/* ERC20 support */
 	ERC20() WalletERC20
 
+	/* StableCoin support */
+	StableCoin() WalletStableCoin
+
 	/*
 		ResetPool clears the cached ChainID and TransactOpts.
 		Call this when you need to refresh the cached values.
@@ -391,6 +394,10 @@ func (w *wallet) ContractCall(
 
 func (w *wallet) ERC20() WalletERC20 {
 	return &walletERC20{w: w}
+}
+
+func (w *wallet) StableCoin() WalletStableCoin {
+	return &walletStableCoin{walletERC20{w: w}}
 }
 
 func (w *wallet) buildAuth() (*bind.TransactOpts, error) {


### PR DESCRIPTION
## Summary

- Add `IStableCoin` interface (embeds `IERC20`) and `NewStableCoinNamespace` constructor in `namespace/`
- Add `WalletStableCoin` interface and `wallet.StableCoin()` method in `wallet/`
- Expose `Alchemy.StableCoin namespace.IStableCoin` field in `gas/alchemy.go`
- Add e2e scenario (`TestScenario_StableCoin`) and docs (`docs/docs/stablecoin-namespace/`)

`IStableCoin` embeds `IERC20` with no additions for now. `stableCoin` struct embeds `*ERC20` to delegate all methods. When FiatToken-specific methods (pause, mint, blacklist, etc.) are added via the sub-issues, they will extend `IStableCoin` and `stableCoin` independently without touching `IERC20` or `ERC20`.

## Related Issues

closes #298

FiatToken sub-issues created:
- #363 pause/unpause/paused
- #364 mint/burn
- #365 blacklist
- #366 minter management
- #367 role getters
- #368 role update methods
- #369 currency/version
- #370 transferOwnership

## Test plan

- [x] `go test ./namespace/... -run StableCoin` passes
- [x] `go test ./wallet/... -run StableCoin` passes
- [x] `go build ./...` succeeds
- [ ] e2e: `just k-port && just ci-e2e <PORT>` — requires Kurtosis environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)