### PR TITLE
feat: famous stablecoin contract address lookup

### DIFF
--- a/docs/docs/famous/ContractAddress.md
+++ b/docs/docs/famous/ContractAddress.md
@@ -1,0 +1,45 @@
+---
+sidebar_position: 1
+---
+
+# ContractAddress
+
+`famous` is a helper package that provides contract addresses for well-known stablecoins across supported networks.
+
+## ContractAddress
+
+Returns the contract address of a well-known stablecoin on the given network.
+
+```go
+func ContractAddress(network types.Network, symbol string) (common.Address, error)
+```
+
+### Supported Tokens
+
+| Symbol | Networks |
+|--------|----------|
+| USDC   | EthMainnet, PolygonMainnet, PolygonAmoy |
+| USDT   | EthMainnet, PolygonMainnet |
+| JPYC   | EthMainnet, PolygonMainnet |
+
+### Errors
+
+- `famous.ErrNotSupportedNetwork` — the network has no registered stablecoin addresses
+- `famous.ErrNotSupportedSymbol` — the symbol is not registered for the given network
+
+### Example
+
+```go
+import (
+    "github.com/poteto-go/go-alchemy-sdk/famous"
+    "github.com/poteto-go/go-alchemy-sdk/types"
+)
+
+func main() {
+    addr, err := famous.ContractAddress(types.PolygonMainnet, "JPYC")
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(addr.Hex())
+}
+```

--- a/docs/docs/famous/_category_.json
+++ b/docs/docs/famous/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Famous",
+  "position": 14
+}

--- a/famous/stablecoin.go
+++ b/famous/stablecoin.go
@@ -1,0 +1,46 @@
+package famous
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/poteto-go/go-alchemy-sdk/types"
+)
+
+var (
+	ErrNotSupportedNetwork = errors.New("not supported network for this stablecoin")
+	ErrNotSupportedSymbol  = errors.New("not supported stablecoin symbol")
+)
+
+// stablecoinAddresses maps network → token symbol → contract address.
+// Addresses are pre-parsed at init time to avoid repeated hex conversion on each lookup.
+var stablecoinAddresses = map[types.Network]map[string]common.Address{
+	types.EthMainnet: {
+		"USDC": common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+		"USDT": common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7"),
+		"JPYC": common.HexToAddress("0x431D5dfF03120AFA4bDf332c61A6e1766eF37BF9"),
+	},
+	types.PolygonMainnet: {
+		"USDC": common.HexToAddress("0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"),
+		"USDT": common.HexToAddress("0xc2132D05D31c914a87C6611C10748AEb04B58e8F"),
+		"JPYC": common.HexToAddress("0x6AE7Dfc73E0dDE2aa99ac063DcF7e8A63265108c"),
+	},
+	types.PolygonAmoy: {
+		"USDC": common.HexToAddress("0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582"),
+	},
+}
+
+// ContractAddress returns the contract address of a well-known stablecoin on the given network.
+func ContractAddress(network types.Network, symbol string) (common.Address, error) {
+	networkMap, ok := stablecoinAddresses[network]
+	if !ok {
+		return common.Address{}, ErrNotSupportedNetwork
+	}
+
+	addr, ok := networkMap[symbol]
+	if !ok {
+		return common.Address{}, ErrNotSupportedSymbol
+	}
+
+	return addr, nil
+}

--- a/famous/stablecoin_test.go
+++ b/famous/stablecoin_test.go
@@ -1,0 +1,78 @@
+package famous_test
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/poteto-go/go-alchemy-sdk/famous"
+	"github.com/poteto-go/go-alchemy-sdk/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContractAddress(t *testing.T) {
+	t.Run("returns known addresses", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			network types.Network
+			symbol  string
+			want    common.Address
+		}{
+			{
+				"USDC on Ethereum mainnet",
+				types.EthMainnet, "USDC",
+				common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+			},
+			{
+				"USDT on Ethereum mainnet",
+				types.EthMainnet, "USDT",
+				common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7"),
+			},
+			{
+				"JPYC on Ethereum mainnet",
+				types.EthMainnet, "JPYC",
+				common.HexToAddress("0x431D5dfF03120AFA4bDf332c61A6e1766eF37BF9"),
+			},
+			{
+				"USDC on Polygon mainnet",
+				types.PolygonMainnet, "USDC",
+				common.HexToAddress("0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"),
+			},
+			{
+				"USDT on Polygon mainnet",
+				types.PolygonMainnet, "USDT",
+				common.HexToAddress("0xc2132D05D31c914a87C6611C10748AEb04B58e8F"),
+			},
+			{
+				"JPYC on Polygon mainnet",
+				types.PolygonMainnet, "JPYC",
+				common.HexToAddress("0x6AE7Dfc73E0dDE2aa99ac063DcF7e8A63265108c"),
+			},
+			{
+				"USDC on Polygon Amoy",
+				types.PolygonAmoy, "USDC",
+				common.HexToAddress("0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582"),
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				addr, err := famous.ContractAddress(tt.network, tt.symbol)
+
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, addr)
+			})
+		}
+	})
+
+	t.Run("returns error for unsupported network", func(t *testing.T) {
+		_, err := famous.ContractAddress(types.SolanaMainnet, "USDC")
+
+		assert.ErrorIs(t, err, famous.ErrNotSupportedNetwork)
+	})
+
+	t.Run("returns error for unsupported symbol", func(t *testing.T) {
+		_, err := famous.ContractAddress(types.EthMainnet, "UNKNOWN")
+
+		assert.ErrorIs(t, err, famous.ErrNotSupportedSymbol)
+	})
+}


### PR DESCRIPTION
## Summary

- Introduces `famous.ContractAddress(network, symbol)` — a simple lookup that returns the `common.Address` of well-known stablecoins (USDC, USDT, JPYC) for supported networks (Ethereum mainnet, Polygon mainnet, Polygon Amoy)
- Contract addresses are stored pre-parsed as `common.Address` (avoids per-call hex conversion)
- The address map is private inside the `famous` package — no layering violation with the `constant` package
- Errors (`ErrNotSupportedNetwork`, `ErrNotSupportedSymbol`) are scoped to the `famous` package as they are domain-specific
- Public API docs added under `docs/docs/famous/`

### Usage
```go
addr, err := famous.ContractAddress(types.PolygonMainnet, "JPYC")
```

## Test plan
- [x] Table-driven unit tests cover all 7 supported (network, symbol) pairs with exact address assertions
- [x] Error path tests for unsupported network and unsupported symbol
- [x] Full unit test suite passes (`just ut`)

closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)