### PR TITLE
feat: add mint/burn support to WalletStableCoin (#365)

### DIFF
--- a/constant/erc20_methods.go
+++ b/constant/erc20_methods.go
@@ -10,4 +10,6 @@ var (
 	NameFnSignature         = []byte("name()")
 	SymbolFnSignature       = []byte("symbol()")
 	DecimalsFnSignature     = []byte("decimals()")
+	MintFnSignature         = []byte("mint(address,uint256)")
+	BurnFnSignature         = []byte("burn(uint256)")
 )

--- a/docs/docs/wallet/StableCoin.md
+++ b/docs/docs/wallet/StableCoin.md
@@ -100,3 +100,40 @@ receipt, err := w.StableCoin().TransferFrom(
 	nil,
 )
 ```
+
+### Mint & MintNoWait
+
+Mint StableCoin tokens to an address. Requires the caller to have the minter role (e.g. configured via `configureMinter` on FiatToken/USDC).
+
+```go
+func Mint(ctx context.Context, contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*types.Receipt, error)
+func MintNoWait(contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error)
+```
+
+```go
+receipt, err := w.StableCoin().Mint(
+	context.Background(),
+	contractAddress,
+	"<toAddress>",
+	big.NewInt(100),
+	nil,
+)
+```
+
+### Burn & BurnNoWait
+
+Burn StableCoin tokens from the caller's own balance. Requires the caller to have the minter role (FiatToken/USDC behavior).
+
+```go
+func Burn(ctx context.Context, contractAddress string, amount *big.Int, gasLimit *uint64) (*types.Receipt, error)
+func BurnNoWait(contractAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error)
+```
+
+```go
+receipt, err := w.StableCoin().Burn(
+	context.Background(),
+	contractAddress,
+	big.NewInt(100),
+	nil,
+)
+```

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -387,6 +387,61 @@ func TestScenario_StableCoin_FiatToken(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, 0, totalSupply.Cmp(big.NewInt(0)))
 		})
+
+		t.Run("can configure minter and mint tokens", func(t *testing.T) {
+			fiatToken := artifacts.NewFiatToken()
+
+			// configure minter allowance (owner == initAddress in this test setup)
+			configureMinterData := fiatToken.PackConfigureMinter(
+				common.HexToAddress(initAddress),
+				big.NewInt(1_000_000),
+			)
+			txHash, err := w.SendTransaction(types.TransactionRequest{
+				From:     initAddress,
+				To:       contractHex,
+				Value:    "0x0",
+				GasLimit: 300000,
+				Data:     configureMinterData,
+			})
+			assert.Nil(t, err)
+			_, err = alchemy.Transact.WaitMined(context.Background(), txHash.Hex())
+			assert.Nil(t, err)
+
+			mintAmount := big.NewInt(500_000)
+			receipt, err := w.StableCoin().Mint(
+				context.Background(),
+				contractHex,
+				initAddress,
+				mintAmount,
+				nil,
+			)
+			assert.Nil(t, err)
+			assert.NotNil(t, receipt)
+
+			totalSupply, err := w.StableCoin().TotalSupply(contractHex)
+			assert.Nil(t, err)
+			assert.Equal(t, 0, totalSupply.Cmp(mintAmount))
+		})
+
+		t.Run("can burn tokens", func(t *testing.T) {
+			burnAmount := big.NewInt(100_000)
+
+			supplyBefore, err := w.StableCoin().TotalSupply(contractHex)
+			assert.Nil(t, err)
+
+			receipt, err := w.StableCoin().Burn(
+				context.Background(),
+				contractHex,
+				burnAmount,
+				nil,
+			)
+			assert.Nil(t, err)
+			assert.NotNil(t, receipt)
+
+			supplyAfter, err := w.StableCoin().TotalSupply(contractHex)
+			assert.Nil(t, err)
+			assert.Equal(t, 0, new(big.Int).Sub(supplyBefore, burnAmount).Cmp(supplyAfter))
+		})
 	})
 }
 

--- a/wallet/erc20.go
+++ b/wallet/erc20.go
@@ -135,56 +135,35 @@ func resolveGasLimit(gasLimit *uint64) uint64 {
 	return *gasLimit
 }
 
-func (api *walletERC20) TransferNoWait(contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
-	provider := api.w.snapshot()
-	if provider == nil {
+func (api *walletERC20) sendERC20Tx(contractAddress string, gasLimit *uint64, sig []byte, params ...[]byte) (common.Hash, error) {
+	if api.w.snapshot() == nil {
 		return common.Hash{}, constant.ErrWalletIsNotConnected
 	}
+	data, err := buildERC20TxData(sig, params...)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return api.w.SendTransaction(types.TransactionRequest{
+		From:     api.w.GetAddress(),
+		To:       contractAddress,
+		Value:    "0x0",
+		GasLimit: resolveGasLimit(gasLimit),
+		Data:     data,
+	})
+}
 
-	data, err := buildERC20TxData(
-		constant.TransferFnSignature,
+func (api *walletERC20) TransferNoWait(contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
+	return api.sendERC20Tx(contractAddress, gasLimit, constant.TransferFnSignature,
 		common.LeftPadBytes(common.HexToAddress(toAddress).Bytes(), 32),
 		common.LeftPadBytes(amount.Bytes(), 32),
 	)
-	if err != nil {
-		return common.Hash{}, err
-	}
-
-	txRequest := types.TransactionRequest{
-		From:     api.w.GetAddress(),
-		To:       contractAddress,
-		Value:    "0x0",
-		GasLimit: resolveGasLimit(gasLimit),
-		Data:     data,
-	}
-
-	return api.w.SendTransaction(txRequest)
 }
 
 func (api *walletERC20) ApproveNoWait(contractAddress, spenderAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
-	provider := api.w.snapshot()
-	if provider == nil {
-		return common.Hash{}, constant.ErrWalletIsNotConnected
-	}
-
-	data, err := buildERC20TxData(
-		constant.ApproveFnSignature,
+	return api.sendERC20Tx(contractAddress, gasLimit, constant.ApproveFnSignature,
 		common.LeftPadBytes(common.HexToAddress(spenderAddress).Bytes(), 32),
 		common.LeftPadBytes(amount.Bytes(), 32),
 	)
-	if err != nil {
-		return common.Hash{}, err
-	}
-
-	txRequest := types.TransactionRequest{
-		From:     api.w.GetAddress(),
-		To:       contractAddress,
-		Value:    "0x0",
-		GasLimit: resolveGasLimit(gasLimit),
-		Data:     data,
-	}
-
-	return api.w.SendTransaction(txRequest)
 }
 
 func (api *walletERC20) Approve(ctx context.Context, contractAddress, spenderAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
@@ -194,30 +173,11 @@ func (api *walletERC20) Approve(ctx context.Context, contractAddress, spenderAdd
 }
 
 func (api *walletERC20) TransferFromNoWait(contractAddress, fromAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
-	provider := api.w.snapshot()
-	if provider == nil {
-		return common.Hash{}, constant.ErrWalletIsNotConnected
-	}
-
-	data, err := buildERC20TxData(
-		constant.TransferFromFnSignature,
+	return api.sendERC20Tx(contractAddress, gasLimit, constant.TransferFromFnSignature,
 		common.LeftPadBytes(common.HexToAddress(fromAddress).Bytes(), 32),
 		common.LeftPadBytes(common.HexToAddress(toAddress).Bytes(), 32),
 		common.LeftPadBytes(amount.Bytes(), 32),
 	)
-	if err != nil {
-		return common.Hash{}, err
-	}
-
-	txRequest := types.TransactionRequest{
-		From:     api.w.GetAddress(),
-		To:       contractAddress,
-		Value:    "0x0",
-		GasLimit: resolveGasLimit(gasLimit),
-		Data:     data,
-	}
-
-	return api.w.SendTransaction(txRequest)
 }
 
 func (api *walletERC20) TransferFrom(ctx context.Context, contractAddress, fromAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {

--- a/wallet/stablecoin.go
+++ b/wallet/stablecoin.go
@@ -1,9 +1,110 @@
 package wallet
 
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/poteto-go/go-alchemy-sdk/constant"
+	"github.com/poteto-go/go-alchemy-sdk/types"
+)
+
 type WalletStableCoin interface {
 	WalletERC20
+
+	/*
+		mint stablecoin tokens to an address (requires minter role)
+			- wait for mined
+			- gas limit is 300000 for default
+			- stops waiting when ctx is canceled
+	*/
+	Mint(ctx context.Context, contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error)
+
+	/*
+		mint stablecoin tokens to an address (requires minter role)
+			- gas limit is 300000 for default
+	*/
+	MintNoWait(contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error)
+
+	/*
+		burn stablecoin tokens from the caller's balance (requires minter role)
+			- wait for mined
+			- gas limit is 300000 for default
+			- stops waiting when ctx is canceled
+	*/
+	Burn(ctx context.Context, contractAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error)
+
+	/*
+		burn stablecoin tokens from the caller's balance (requires minter role)
+			- gas limit is 300000 for default
+	*/
+	BurnNoWait(contractAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error)
 }
 
 type walletStableCoin struct {
 	walletERC20
+}
+
+func (api *walletStableCoin) MintNoWait(contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
+	provider := api.w.snapshot()
+	if provider == nil {
+		return common.Hash{}, constant.ErrWalletIsNotConnected
+	}
+
+	data, err := buildERC20TxData(
+		constant.MintFnSignature,
+		common.LeftPadBytes(common.HexToAddress(toAddress).Bytes(), 32),
+		common.LeftPadBytes(amount.Bytes(), 32),
+	)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	txRequest := types.TransactionRequest{
+		From:     api.w.GetAddress(),
+		To:       contractAddress,
+		Value:    "0x0",
+		GasLimit: resolveGasLimit(gasLimit),
+		Data:     data,
+	}
+
+	return api.w.SendTransaction(txRequest)
+}
+
+func (api *walletStableCoin) Mint(ctx context.Context, contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
+	return api.waitMined(ctx, func() (common.Hash, error) {
+		return api.MintNoWait(contractAddress, toAddress, amount, gasLimit)
+	})
+}
+
+func (api *walletStableCoin) BurnNoWait(contractAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
+	provider := api.w.snapshot()
+	if provider == nil {
+		return common.Hash{}, constant.ErrWalletIsNotConnected
+	}
+
+	data, err := buildERC20TxData(
+		constant.BurnFnSignature,
+		common.LeftPadBytes(amount.Bytes(), 32),
+	)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	txRequest := types.TransactionRequest{
+		From:     api.w.GetAddress(),
+		To:       contractAddress,
+		Value:    "0x0",
+		GasLimit: resolveGasLimit(gasLimit),
+		Data:     data,
+	}
+
+	return api.w.SendTransaction(txRequest)
+}
+
+func (api *walletStableCoin) Burn(ctx context.Context, contractAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
+	return api.waitMined(ctx, func() (common.Hash, error) {
+		return api.BurnNoWait(contractAddress, amount, gasLimit)
+	})
 }

--- a/wallet/stablecoin.go
+++ b/wallet/stablecoin.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/poteto-go/go-alchemy-sdk/constant"
-	"github.com/poteto-go/go-alchemy-sdk/types"
 )
 
 type WalletStableCoin interface {
@@ -47,29 +46,10 @@ type walletStableCoin struct {
 }
 
 func (api *walletStableCoin) MintNoWait(contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
-	provider := api.w.snapshot()
-	if provider == nil {
-		return common.Hash{}, constant.ErrWalletIsNotConnected
-	}
-
-	data, err := buildERC20TxData(
-		constant.MintFnSignature,
+	return api.sendERC20Tx(contractAddress, gasLimit, constant.MintFnSignature,
 		common.LeftPadBytes(common.HexToAddress(toAddress).Bytes(), 32),
 		common.LeftPadBytes(amount.Bytes(), 32),
 	)
-	if err != nil {
-		return common.Hash{}, err
-	}
-
-	txRequest := types.TransactionRequest{
-		From:     api.w.GetAddress(),
-		To:       contractAddress,
-		Value:    "0x0",
-		GasLimit: resolveGasLimit(gasLimit),
-		Data:     data,
-	}
-
-	return api.w.SendTransaction(txRequest)
 }
 
 func (api *walletStableCoin) Mint(ctx context.Context, contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
@@ -79,28 +59,9 @@ func (api *walletStableCoin) Mint(ctx context.Context, contractAddress, toAddres
 }
 
 func (api *walletStableCoin) BurnNoWait(contractAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
-	provider := api.w.snapshot()
-	if provider == nil {
-		return common.Hash{}, constant.ErrWalletIsNotConnected
-	}
-
-	data, err := buildERC20TxData(
-		constant.BurnFnSignature,
+	return api.sendERC20Tx(contractAddress, gasLimit, constant.BurnFnSignature,
 		common.LeftPadBytes(amount.Bytes(), 32),
 	)
-	if err != nil {
-		return common.Hash{}, err
-	}
-
-	txRequest := types.TransactionRequest{
-		From:     api.w.GetAddress(),
-		To:       contractAddress,
-		Value:    "0x0",
-		GasLimit: resolveGasLimit(gasLimit),
-		Data:     data,
-	}
-
-	return api.w.SendTransaction(txRequest)
 }
 
 func (api *walletStableCoin) Burn(ctx context.Context, contractAddress string, amount *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {

--- a/wallet/stablecoin_test.go
+++ b/wallet/stablecoin_test.go
@@ -1,8 +1,18 @@
 package wallet
 
 import (
+	"context"
+	"errors"
+	"math/big"
+	"reflect"
 	"testing"
 
+	"github.com/agiledragon/gomonkey"
+	"github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/poteto-go/go-alchemy-sdk/constant"
+	"github.com/poteto-go/go-alchemy-sdk/ether"
+	"github.com/poteto-go/go-alchemy-sdk/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,5 +23,189 @@ func TestWallet_StableCoin(t *testing.T) {
 		sc := w.StableCoin()
 
 		assert.NotNil(t, sc)
+	})
+}
+
+func TestWallet_StableCoin_MintNoWait(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	toAddress := "0xE25583099BA105D9ec0A67f5Ae86D90e50036425"
+	expectedHash := common.HexToHash("0x123")
+
+	t.Run("can mint stablecoin", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return expectedHash, nil
+			},
+		)
+
+		hash, err := w.StableCoin().MintNoWait(contractAddress, toAddress, big.NewInt(100), nil)
+
+		assert.Nil(t, err)
+		assert.Equal(t, expectedHash, hash)
+	})
+
+	t.Run("handle error on mint", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return common.Hash{}, errors.New("error")
+			},
+		)
+
+		_, err := w.StableCoin().MintNoWait(contractAddress, toAddress, big.NewInt(100), nil)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.StableCoin().MintNoWait(contractAddress, toAddress, big.NewInt(100), nil)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}
+
+func TestWallet_StableCoin_Mint(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	toAddress := "0xE25583099BA105D9ec0A67f5Ae86D90e50036425"
+	expectedHash := common.HexToHash("0x123")
+
+	t.Run("can mint stablecoin and wait", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return expectedHash, nil
+			},
+		)
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"WaitMined",
+			func(_ *ether.Ether, _ context.Context, _ common.Hash) (*gethTypes.Receipt, error) {
+				return &gethTypes.Receipt{}, nil
+			},
+		)
+
+		_, err := w.StableCoin().Mint(context.Background(), contractAddress, toAddress, big.NewInt(100), nil)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.StableCoin().Mint(context.Background(), contractAddress, toAddress, big.NewInt(100), nil)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}
+
+func TestWallet_StableCoin_BurnNoWait(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	expectedHash := common.HexToHash("0x123")
+
+	t.Run("can burn stablecoin", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return expectedHash, nil
+			},
+		)
+
+		hash, err := w.StableCoin().BurnNoWait(contractAddress, big.NewInt(50), nil)
+
+		assert.Nil(t, err)
+		assert.Equal(t, expectedHash, hash)
+	})
+
+	t.Run("handle error on burn", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return common.Hash{}, errors.New("error")
+			},
+		)
+
+		_, err := w.StableCoin().BurnNoWait(contractAddress, big.NewInt(50), nil)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.StableCoin().BurnNoWait(contractAddress, big.NewInt(50), nil)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}
+
+func TestWallet_StableCoin_Burn(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	expectedHash := common.HexToHash("0x123")
+
+	t.Run("can burn stablecoin and wait", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return expectedHash, nil
+			},
+		)
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"WaitMined",
+			func(_ *ether.Ether, _ context.Context, _ common.Hash) (*gethTypes.Receipt, error) {
+				return &gethTypes.Receipt{}, nil
+			},
+		)
+
+		_, err := w.StableCoin().Burn(context.Background(), contractAddress, big.NewInt(50), nil)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.StableCoin().Burn(context.Background(), contractAddress, big.NewInt(50), nil)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
 	})
 }


### PR DESCRIPTION
## Summary

- Add `Mint` / `MintNoWait` methods to `WalletStableCoin` — mints tokens to an address (requires minter role, e.g. FiatToken/USDC)
- Add `Burn` / `BurnNoWait` methods to `WalletStableCoin` — burns tokens from the caller's own balance
- Add `MintFnSignature` / `BurnFnSignature` ABI constants
- E2e tests: configure minter → mint → verify supply, then burn → verify supply decreases
- Docs updated in `docs/docs/wallet/StableCoin.md`

## Test plan

- [x] Unit tests pass: `TestWallet_StableCoin_Mint`, `TestWallet_StableCoin_MintNoWait`, `TestWallet_StableCoin_Burn`, `TestWallet_StableCoin_BurnNoWait`
- [x] Full `just ut` green
- [x] E2e compiles (`go build ./e2e/...`)
- [ ] Run e2e against Kurtosis: `just k-port && just ci-e2e <PORT>`

refs: #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)