### PR TITLE
feat: FiatToken role getter methods for IStableCoin (#366)

### DIFF
--- a/constant/erc20_methods.go
+++ b/constant/erc20_methods.go
@@ -22,4 +22,7 @@ var (
 	OwnerFnSignature             = []byte("owner()")
 	CurrencyFnSignature          = []byte("currency()")
 	VersionFnSignature           = []byte("version()")
+	MasterMinterFnSignature      = []byte("masterMinter()")
+	PauserFnSignature            = []byte("pauser()")
+	BlacklisterFnSignature       = []byte("blacklister()")
 )

--- a/docs/docs/stablecoin-namespace/Blacklister.md
+++ b/docs/docs/stablecoin-namespace/Blacklister.md
@@ -1,0 +1,18 @@
+![](https://img.shields.io/badge/go-geth-lightblue)
+
+Return the blacklister address of a StableCoin contract (FiatToken/USDC compatibility).
+
+```go
+func Blacklister(
+    contractAddress string,
+) (common.Address, error)
+```
+
+```go
+func main() {
+    ...
+    alchemy := gas.NewAlchemy(setting)
+    ...
+    blacklister, err := alchemy.StableCoin.Blacklister(contractAddress)
+}
+```

--- a/docs/docs/stablecoin-namespace/MasterMinter.md
+++ b/docs/docs/stablecoin-namespace/MasterMinter.md
@@ -1,0 +1,18 @@
+![](https://img.shields.io/badge/go-geth-lightblue)
+
+Return the master minter address of a StableCoin contract (FiatToken/USDC compatibility).
+
+```go
+func MasterMinter(
+    contractAddress string,
+) (common.Address, error)
+```
+
+```go
+func main() {
+    ...
+    alchemy := gas.NewAlchemy(setting)
+    ...
+    masterMinter, err := alchemy.StableCoin.MasterMinter(contractAddress)
+}
+```

--- a/docs/docs/stablecoin-namespace/Pauser.md
+++ b/docs/docs/stablecoin-namespace/Pauser.md
@@ -1,0 +1,18 @@
+![](https://img.shields.io/badge/go-geth-lightblue)
+
+Return the pauser address of a StableCoin contract (FiatToken/USDC compatibility).
+
+```go
+func Pauser(
+    contractAddress string,
+) (common.Address, error)
+```
+
+```go
+func main() {
+    ...
+    alchemy := gas.NewAlchemy(setting)
+    ...
+    pauser, err := alchemy.StableCoin.Pauser(contractAddress)
+}
+```

--- a/docs/docs/wallet/StableCoin.md
+++ b/docs/docs/wallet/StableCoin.md
@@ -57,6 +57,10 @@ You can fetch token metadata and balance information:
 - BalanceOf
 - Currency
 - Version
+- MasterMinter
+- Pauser
+- Blacklister
+- Owner
 
 ## Write Methods
 
@@ -242,6 +246,42 @@ receipt, err := w.StableCoin().TransferOwnership(
 	"<newOwnerAddress>",
 	nil,
 )
+```
+
+### MasterMinter
+
+Get the master minter address of the contract. FiatToken/USDC compatibility.
+
+```go
+func MasterMinter(contractAddress string) (common.Address, error)
+```
+
+```go
+masterMinter, err := w.StableCoin().MasterMinter(contractAddress)
+```
+
+### Pauser
+
+Get the pauser address of the contract. FiatToken/USDC compatibility.
+
+```go
+func Pauser(contractAddress string) (common.Address, error)
+```
+
+```go
+pauser, err := w.StableCoin().Pauser(contractAddress)
+```
+
+### Blacklister
+
+Get the blacklister address of the contract. FiatToken/USDC compatibility.
+
+```go
+func Blacklister(contractAddress string) (common.Address, error)
+```
+
+```go
+blacklister, err := w.StableCoin().Blacklister(contractAddress)
 ```
 
 ### Owner

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -397,15 +397,17 @@ func TestScenario_StableCoin_FiatToken(t *testing.T) {
 		})
 
 		t.Run("can read role addresses via StableCoin", func(t *testing.T) {
-			masterMinter, err := w.StableCoin().MasterMinter(contractHex)
+			sc := w.StableCoin()
+
+			masterMinter, err := sc.MasterMinter(contractHex)
 			assert.Nil(t, err)
 			assert.Equal(t, common.HexToAddress(initAddress), masterMinter)
 
-			pauser, err := w.StableCoin().Pauser(contractHex)
+			pauser, err := sc.Pauser(contractHex)
 			assert.Nil(t, err)
 			assert.Equal(t, common.HexToAddress(initAddress), pauser)
 
-			blacklister, err := w.StableCoin().Blacklister(contractHex)
+			blacklister, err := sc.Blacklister(contractHex)
 			assert.Nil(t, err)
 			assert.Equal(t, common.HexToAddress(initAddress), blacklister)
 		})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -396,6 +396,20 @@ func TestScenario_StableCoin_FiatToken(t *testing.T) {
 			assert.Equal(t, "1", version)
 		})
 
+		t.Run("can read role addresses via StableCoin", func(t *testing.T) {
+			masterMinter, err := w.StableCoin().MasterMinter(contractHex)
+			assert.Nil(t, err)
+			assert.Equal(t, common.HexToAddress(initAddress), masterMinter)
+
+			pauser, err := w.StableCoin().Pauser(contractHex)
+			assert.Nil(t, err)
+			assert.Equal(t, common.HexToAddress(initAddress), pauser)
+
+			blacklister, err := w.StableCoin().Blacklister(contractHex)
+			assert.Nil(t, err)
+			assert.Equal(t, common.HexToAddress(initAddress), blacklister)
+		})
+
 		t.Run("can configure minter and mint tokens", func(t *testing.T) {
 			fiatToken := artifacts.NewFiatToken()
 

--- a/namespace/stablecoin_namespace.go
+++ b/namespace/stablecoin_namespace.go
@@ -92,19 +92,12 @@ func (s *stableCoin) Paused(contractAddress string) (bool, error) {
 	return decodeBoolOutput(output), nil
 }
 
-func (s *stableCoin) decodeAddressOutput(output []byte) (common.Address, error) {
-	if len(output) < constant.ABIWordSize {
-		return common.Address{}, nil
-	}
-	return common.BytesToAddress(output[constant.ABIAddressOffset:constant.ABIWordSize]), nil
-}
-
 func (s *stableCoin) Owner(contractAddress string) (common.Address, error) {
 	output, err := s.ether.CallReadMethod(constant.OwnerFnSignature, contractAddress)
 	if err != nil {
 		return common.Address{}, err
 	}
-	return s.decodeAddressOutput(output)
+	return utils.DecodeABIAddress(output), nil
 }
 
 func (s *stableCoin) MasterMinter(contractAddress string) (common.Address, error) {
@@ -112,7 +105,7 @@ func (s *stableCoin) MasterMinter(contractAddress string) (common.Address, error
 	if err != nil {
 		return common.Address{}, err
 	}
-	return s.decodeAddressOutput(output)
+	return utils.DecodeABIAddress(output), nil
 }
 
 func (s *stableCoin) Pauser(contractAddress string) (common.Address, error) {
@@ -120,7 +113,7 @@ func (s *stableCoin) Pauser(contractAddress string) (common.Address, error) {
 	if err != nil {
 		return common.Address{}, err
 	}
-	return s.decodeAddressOutput(output)
+	return utils.DecodeABIAddress(output), nil
 }
 
 func (s *stableCoin) Blacklister(contractAddress string) (common.Address, error) {
@@ -128,5 +121,5 @@ func (s *stableCoin) Blacklister(contractAddress string) (common.Address, error)
 	if err != nil {
 		return common.Address{}, err
 	}
-	return s.decodeAddressOutput(output)
+	return utils.DecodeABIAddress(output), nil
 }

--- a/namespace/stablecoin_namespace.go
+++ b/namespace/stablecoin_namespace.go
@@ -97,7 +97,7 @@ func (s *stableCoin) Owner(contractAddress string) (common.Address, error) {
 	if err != nil {
 		return common.Address{}, err
 	}
-	return utils.DecodeABIAddress(output), nil
+	return utils.DecodeABIAddress(output)
 }
 
 func (s *stableCoin) MasterMinter(contractAddress string) (common.Address, error) {
@@ -105,7 +105,7 @@ func (s *stableCoin) MasterMinter(contractAddress string) (common.Address, error
 	if err != nil {
 		return common.Address{}, err
 	}
-	return utils.DecodeABIAddress(output), nil
+	return utils.DecodeABIAddress(output)
 }
 
 func (s *stableCoin) Pauser(contractAddress string) (common.Address, error) {
@@ -113,7 +113,7 @@ func (s *stableCoin) Pauser(contractAddress string) (common.Address, error) {
 	if err != nil {
 		return common.Address{}, err
 	}
-	return utils.DecodeABIAddress(output), nil
+	return utils.DecodeABIAddress(output)
 }
 
 func (s *stableCoin) Blacklister(contractAddress string) (common.Address, error) {
@@ -121,5 +121,5 @@ func (s *stableCoin) Blacklister(contractAddress string) (common.Address, error)
 	if err != nil {
 		return common.Address{}, err
 	}
-	return utils.DecodeABIAddress(output), nil
+	return utils.DecodeABIAddress(output)
 }

--- a/namespace/stablecoin_namespace.go
+++ b/namespace/stablecoin_namespace.go
@@ -19,6 +19,15 @@ type IStableCoin interface {
 	// Owner returns the current owner address of the contract.
 	Owner(contractAddress string) (common.Address, error)
 
+	// MasterMinter returns the master minter address of the contract.
+	MasterMinter(contractAddress string) (common.Address, error)
+
+	// Pauser returns the pauser address of the contract.
+	Pauser(contractAddress string) (common.Address, error)
+
+	// Blacklister returns the blacklister address of the contract.
+	Blacklister(contractAddress string) (common.Address, error)
+
 	// Currency returns the currency identifier of the token (e.g. "USD").
 	Currency(contractAddress string) (string, error)
 
@@ -83,16 +92,41 @@ func (s *stableCoin) Paused(contractAddress string) (bool, error) {
 	return decodeBoolOutput(output), nil
 }
 
-func (s *stableCoin) Owner(contractAddress string) (common.Address, error) {
-	output, err := s.ether.CallReadMethod(
-		constant.OwnerFnSignature,
-		contractAddress,
-	)
-	if err != nil {
-		return common.Address{}, err
-	}
+func (s *stableCoin) decodeAddressOutput(output []byte) (common.Address, error) {
 	if len(output) < constant.ABIWordSize {
 		return common.Address{}, nil
 	}
 	return common.BytesToAddress(output[constant.ABIAddressOffset:constant.ABIWordSize]), nil
+}
+
+func (s *stableCoin) Owner(contractAddress string) (common.Address, error) {
+	output, err := s.ether.CallReadMethod(constant.OwnerFnSignature, contractAddress)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return s.decodeAddressOutput(output)
+}
+
+func (s *stableCoin) MasterMinter(contractAddress string) (common.Address, error) {
+	output, err := s.ether.CallReadMethod(constant.MasterMinterFnSignature, contractAddress)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return s.decodeAddressOutput(output)
+}
+
+func (s *stableCoin) Pauser(contractAddress string) (common.Address, error) {
+	output, err := s.ether.CallReadMethod(constant.PauserFnSignature, contractAddress)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return s.decodeAddressOutput(output)
+}
+
+func (s *stableCoin) Blacklister(contractAddress string) (common.Address, error) {
+	output, err := s.ether.CallReadMethod(constant.BlacklisterFnSignature, contractAddress)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return s.decodeAddressOutput(output)
 }

--- a/namespace/stablecoin_namespace_test.go
+++ b/namespace/stablecoin_namespace_test.go
@@ -216,6 +216,126 @@ func TestStableCoin_Paused(t *testing.T) {
 	})
 }
 
+func TestStableCoin_MasterMinter(t *testing.T) {
+	contractAddress := "0x1234567890abcdef1234567890abcdef12345678"
+	masterMinterAddress := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+
+	t.Run("returns master minter address", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+		expected := make([]byte, 32)
+		copy(expected[12:], masterMinterAddress.Bytes())
+
+		patches.ApplyMethod(reflect.TypeOf(eth), "CallContract", func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+			return expected, nil
+		})
+
+		result, err := sc.MasterMinter(contractAddress)
+
+		assert.NoError(t, err)
+		assert.Equal(t, masterMinterAddress, result)
+	})
+
+	t.Run("returns error if contract call fails", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		patches.ApplyMethod(reflect.TypeOf(eth), "CallContract", func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+			return nil, assert.AnError
+		})
+
+		_, err := sc.MasterMinter(contractAddress)
+
+		assert.Error(t, err)
+	})
+}
+
+func TestStableCoin_Pauser(t *testing.T) {
+	contractAddress := "0x1234567890abcdef1234567890abcdef12345678"
+	pauserAddress := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+
+	t.Run("returns pauser address", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+		expected := make([]byte, 32)
+		copy(expected[12:], pauserAddress.Bytes())
+
+		patches.ApplyMethod(reflect.TypeOf(eth), "CallContract", func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+			return expected, nil
+		})
+
+		result, err := sc.Pauser(contractAddress)
+
+		assert.NoError(t, err)
+		assert.Equal(t, pauserAddress, result)
+	})
+
+	t.Run("returns error if contract call fails", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		patches.ApplyMethod(reflect.TypeOf(eth), "CallContract", func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+			return nil, assert.AnError
+		})
+
+		_, err := sc.Pauser(contractAddress)
+
+		assert.Error(t, err)
+	})
+}
+
+func TestStableCoin_Blacklister(t *testing.T) {
+	contractAddress := "0x1234567890abcdef1234567890abcdef12345678"
+	blacklisterAddress := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+
+	t.Run("returns blacklister address", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+		expected := make([]byte, 32)
+		copy(expected[12:], blacklisterAddress.Bytes())
+
+		patches.ApplyMethod(reflect.TypeOf(eth), "CallContract", func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+			return expected, nil
+		})
+
+		result, err := sc.Blacklister(contractAddress)
+
+		assert.NoError(t, err)
+		assert.Equal(t, blacklisterAddress, result)
+	})
+
+	t.Run("returns error if contract call fails", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		patches.ApplyMethod(reflect.TypeOf(eth), "CallContract", func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+			return nil, assert.AnError
+		})
+
+		_, err := sc.Blacklister(contractAddress)
+
+		assert.Error(t, err)
+	})
+}
+
 func TestStableCoin_Owner(t *testing.T) {
 	contractAddress := "0x1234567890abcdef1234567890abcdef12345678"
 	ownerAddress := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")

--- a/utils/abi.go
+++ b/utils/abi.go
@@ -20,11 +20,11 @@ func EncodeABIString(s string) []byte {
 }
 
 // DecodeABIAddress decodes an ABI-encoded address (left-padded 32-byte word).
-func DecodeABIAddress(output []byte) common.Address {
+func DecodeABIAddress(output []byte) (common.Address, error) {
 	if len(output) < constant.ABIWordSize {
-		return common.Address{}
+		return common.Address{}, fmt.Errorf("invalid ABI address: output too short, got %d bytes", len(output))
 	}
-	return common.BytesToAddress(output[constant.ABIAddressOffset:constant.ABIWordSize])
+	return common.BytesToAddress(output[constant.ABIAddressOffset:constant.ABIWordSize]), nil
 }
 
 // DecodeABIString decodes an ABI-encoded string (offset, length, data).

--- a/utils/abi.go
+++ b/utils/abi.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/poteto-go/go-alchemy-sdk/constant"
 )
 
@@ -16,6 +17,14 @@ func EncodeABIString(s string) []byte {
 	b[constant.ABIStringHeaderSize-1] = byte(dataLen)      // string length
 	copy(b[constant.ABIStringHeaderSize:], s)
 	return b
+}
+
+// DecodeABIAddress decodes an ABI-encoded address (left-padded 32-byte word).
+func DecodeABIAddress(output []byte) common.Address {
+	if len(output) < constant.ABIWordSize {
+		return common.Address{}
+	}
+	return common.BytesToAddress(output[constant.ABIAddressOffset:constant.ABIWordSize])
 }
 
 // DecodeABIString decodes an ABI-encoded string (offset, length, data).

--- a/utils/abi_test.go
+++ b/utils/abi_test.go
@@ -3,10 +3,30 @@ package utils_test
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/poteto-go/go-alchemy-sdk/constant"
 	"github.com/poteto-go/go-alchemy-sdk/utils"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestDecodeABIAddress(t *testing.T) {
+	addr := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+
+	t.Run("decodes left-padded 32-byte word", func(t *testing.T) {
+		input := make([]byte, 32)
+		copy(input[12:], addr.Bytes())
+
+		result := utils.DecodeABIAddress(input)
+
+		assert.Equal(t, addr, result)
+	})
+
+	t.Run("returns zero address for short input", func(t *testing.T) {
+		result := utils.DecodeABIAddress([]byte{0x01})
+
+		assert.Equal(t, common.Address{}, result)
+	})
+}
 
 func TestEncodeABIString(t *testing.T) {
 	t.Run("encode and decode roundtrip", func(t *testing.T) {

--- a/utils/abi_test.go
+++ b/utils/abi_test.go
@@ -16,15 +16,16 @@ func TestDecodeABIAddress(t *testing.T) {
 		input := make([]byte, 32)
 		copy(input[12:], addr.Bytes())
 
-		result := utils.DecodeABIAddress(input)
+		result, err := utils.DecodeABIAddress(input)
 
+		assert.NoError(t, err)
 		assert.Equal(t, addr, result)
 	})
 
-	t.Run("returns zero address for short input", func(t *testing.T) {
-		result := utils.DecodeABIAddress([]byte{0x01})
+	t.Run("returns error for short input", func(t *testing.T) {
+		_, err := utils.DecodeABIAddress([]byte{0x01})
 
-		assert.Equal(t, common.Address{}, result)
+		assert.Error(t, err)
 	})
 }
 

--- a/wallet/stablecoin.go
+++ b/wallet/stablecoin.go
@@ -107,6 +107,21 @@ type WalletStableCoin interface {
 	IsBlacklisted(contractAddress, address string) (bool, error)
 
 	/*
+		return the master minter address of the contract
+	*/
+	MasterMinter(contractAddress string) (common.Address, error)
+
+	/*
+		return the pauser address of the contract
+	*/
+	Pauser(contractAddress string) (common.Address, error)
+
+	/*
+		return the blacklister address of the contract
+	*/
+	Blacklister(contractAddress string) (common.Address, error)
+
+	/*
 		return the current owner address of the contract
 	*/
 	Owner(contractAddress string) (common.Address, error)
@@ -195,6 +210,30 @@ func (api *walletStableCoin) IsBlacklisted(contractAddress, address string) (boo
 		return false, constant.ErrWalletIsNotConnected
 	}
 	return sc.IsBlacklisted(contractAddress, address)
+}
+
+func (api *walletStableCoin) MasterMinter(contractAddress string) (common.Address, error) {
+	sc := api.w.snapshotStableCoin()
+	if sc == nil {
+		return common.Address{}, constant.ErrWalletIsNotConnected
+	}
+	return sc.MasterMinter(contractAddress)
+}
+
+func (api *walletStableCoin) Pauser(contractAddress string) (common.Address, error) {
+	sc := api.w.snapshotStableCoin()
+	if sc == nil {
+		return common.Address{}, constant.ErrWalletIsNotConnected
+	}
+	return sc.Pauser(contractAddress)
+}
+
+func (api *walletStableCoin) Blacklister(contractAddress string) (common.Address, error) {
+	sc := api.w.snapshotStableCoin()
+	if sc == nil {
+		return common.Address{}, constant.ErrWalletIsNotConnected
+	}
+	return sc.Blacklister(contractAddress)
 }
 
 func (api *walletStableCoin) Owner(contractAddress string) (common.Address, error) {

--- a/wallet/stablecoin_test.go
+++ b/wallet/stablecoin_test.go
@@ -757,6 +757,111 @@ func TestWallet_StableCoin_Paused(t *testing.T) {
 	})
 }
 
+func TestWallet_StableCoin_MasterMinter(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	masterMinterAddress := common.HexToAddress("0xE25583099BA105D9ec0A67f5Ae86D90e50036425")
+
+	t.Run("returns master minter address", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+		expected := make([]byte, 32)
+		copy(expected[12:], masterMinterAddress.Bytes())
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"CallContract",
+			func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+				return expected, nil
+			},
+		)
+
+		result, err := w.StableCoin().MasterMinter(contractAddress)
+
+		assert.Nil(t, err)
+		assert.Equal(t, masterMinterAddress, result)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.StableCoin().MasterMinter(contractAddress)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}
+
+func TestWallet_StableCoin_Pauser(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	pauserAddress := common.HexToAddress("0xE25583099BA105D9ec0A67f5Ae86D90e50036425")
+
+	t.Run("returns pauser address", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+		expected := make([]byte, 32)
+		copy(expected[12:], pauserAddress.Bytes())
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"CallContract",
+			func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+				return expected, nil
+			},
+		)
+
+		result, err := w.StableCoin().Pauser(contractAddress)
+
+		assert.Nil(t, err)
+		assert.Equal(t, pauserAddress, result)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.StableCoin().Pauser(contractAddress)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}
+
+func TestWallet_StableCoin_Blacklister(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	blacklisterAddress := common.HexToAddress("0xE25583099BA105D9ec0A67f5Ae86D90e50036425")
+
+	t.Run("returns blacklister address", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+		expected := make([]byte, 32)
+		copy(expected[12:], blacklisterAddress.Bytes())
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"CallContract",
+			func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+				return expected, nil
+			},
+		)
+
+		result, err := w.StableCoin().Blacklister(contractAddress)
+
+		assert.Nil(t, err)
+		assert.Equal(t, blacklisterAddress, result)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.StableCoin().Blacklister(contractAddress)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}
+
 func TestWallet_StableCoin_Owner(t *testing.T) {
 	contractAddress := "0x1234567890123456789012345678901234567890"
 	ownerAddress := common.HexToAddress("0xE25583099BA105D9ec0A67f5Ae86D90e50036425")


### PR DESCRIPTION
## Summary

- Add `MasterMinter()`, `Pauser()`, and `Blacklister()` role getter methods to `IStableCoin` (namespace) and `WalletStableCoin` (wallet), backed by new ABI function signature constants
- Extract `utils.DecodeABIAddress` into `utils/abi.go` alongside the existing `DecodeABIString`, removing the now-unnecessary private method on `stableCoin`
- Add unit tests for all new methods in both `namespace` and `wallet` packages
- Add `utils.DecodeABIAddress` tests in `utils/abi_test.go`
- Update e2e scenario to verify role addresses returned from a deployed FiatToken contract
- Add docs for `MasterMinter`, `Pauser`, `Blacklister` in `stablecoin-namespace/` and `wallet/StableCoin.md`

refs: #366 (Part of SC fully support v0.6.0)

## Test plan

- [ ] `go test ./...` (excluding e2e) passes locally
- [ ] e2e: `just k-port && just ci-e2e <PORT>` — new "can read role addresses via StableCoin" subtest passes
- [ ] `MasterMinter`, `Pauser`, `Blacklister` all return `initAddress` for a FiatToken deployed with `initAddress` for all roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)