### PR TITLE
feat: FiatToken minter management for IStableCoin (#369)

### DIFF
--- a/constant/erc20_methods.go
+++ b/constant/erc20_methods.go
@@ -25,4 +25,8 @@ var (
 	MasterMinterFnSignature      = []byte("masterMinter()")
 	PauserFnSignature            = []byte("pauser()")
 	BlacklisterFnSignature       = []byte("blacklister()")
+	ConfigureMinterFnSignature   = []byte("configureMinter(address,uint256)")
+	RemoveMinterFnSignature      = []byte("removeMinter(address)")
+	MinterAllowanceFnSignature   = []byte("minterAllowance(address)")
+	IsMinterFnSignature          = []byte("isMinter(address)")
 )

--- a/docs/docs/stablecoin-namespace/IsMinter.md
+++ b/docs/docs/stablecoin-namespace/IsMinter.md
@@ -1,0 +1,21 @@
+ref: [Wallet-StableCoin-IsMinter](../wallet/StableCoin.md#isminter)
+
+![](https://img.shields.io/badge/go-geth-lightblue)
+
+Check whether an address is a configured minter on a StableCoin contract (FiatToken/USDC compatibility).
+
+```go
+func IsMinter(
+    contractAddress,
+    address string,
+) (bool, error)
+```
+
+```go
+func main() {
+    ...
+    alchemy := gas.NewAlchemy(setting)
+    ...
+    isMinter, err := alchemy.StableCoin.IsMinter(contractAddress, address)
+}
+```

--- a/docs/docs/stablecoin-namespace/MinterAllowance.md
+++ b/docs/docs/stablecoin-namespace/MinterAllowance.md
@@ -1,0 +1,21 @@
+ref: [Wallet-StableCoin-MinterAllowance](../wallet/StableCoin.md#minterallowance)
+
+![](https://img.shields.io/badge/go-geth-lightblue)
+
+Return the remaining mint allowance for a minter on a StableCoin contract (FiatToken/USDC compatibility).
+
+```go
+func MinterAllowance(
+    contractAddress,
+    address string,
+) (*big.Int, error)
+```
+
+```go
+func main() {
+    ...
+    alchemy := gas.NewAlchemy(setting)
+    ...
+    allowance, err := alchemy.StableCoin.MinterAllowance(contractAddress, address)
+}
+```

--- a/docs/docs/wallet/StableCoin.md
+++ b/docs/docs/wallet/StableCoin.md
@@ -61,6 +61,8 @@ You can fetch token metadata and balance information:
 - Pauser
 - Blacklister
 - Owner
+- IsMinter
+- MinterAllowance
 
 ## Write Methods
 
@@ -318,4 +320,65 @@ func Version(contractAddress string) (string, error)
 
 ```go
 version, err := w.StableCoin().Version(contractAddress)
+```
+
+### ConfigureMinter & ConfigureMinterNoWait
+
+Configure a minter with a mint allowance. Requires the caller to have the masterMinter role (FiatToken/USDC behavior).
+
+```go
+func ConfigureMinter(ctx context.Context, contractAddress, minter string, allowance *big.Int, gasLimit *uint64) (*types.Receipt, error)
+func ConfigureMinterNoWait(contractAddress, minter string, allowance *big.Int, gasLimit *uint64) (common.Hash, error)
+```
+
+```go
+receipt, err := w.StableCoin().ConfigureMinter(
+	context.Background(),
+	contractAddress,
+	"<minterAddress>",
+	big.NewInt(1_000_000),
+	nil,
+)
+```
+
+### RemoveMinter & RemoveMinterNoWait
+
+Remove a minter, revoking their ability to mint. Requires the caller to have the masterMinter role (FiatToken/USDC behavior).
+
+```go
+func RemoveMinter(ctx context.Context, contractAddress, minter string, gasLimit *uint64) (*types.Receipt, error)
+func RemoveMinterNoWait(contractAddress, minter string, gasLimit *uint64) (common.Hash, error)
+```
+
+```go
+receipt, err := w.StableCoin().RemoveMinter(
+	context.Background(),
+	contractAddress,
+	"<minterAddress>",
+	nil,
+)
+```
+
+### IsMinter
+
+Check whether an address is a configured minter on the contract. FiatToken/USDC compatibility.
+
+```go
+func IsMinter(contractAddress, address string) (bool, error)
+```
+
+```go
+isMinter, err := w.StableCoin().IsMinter(contractAddress, "<minterAddress>")
+```
+
+### MinterAllowance
+
+Get the remaining mint allowance for a minter. FiatToken/USDC compatibility.
+
+```go
+func MinterAllowance(contractAddress, address string) (*big.Int, error)
+```
+
+```go
+allowance, err := w.StableCoin().MinterAllowance(contractAddress, "<minterAddress>")
 ```

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -550,6 +550,40 @@ func TestScenario_StableCoin_FiatToken(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, common.HexToAddress(otherAddress), ownerAfter)
 		})
+
+		t.Run("can configure minter, check allowance, and remove minter", func(t *testing.T) {
+			allowance := big.NewInt(5_000_000)
+
+			// address should not be a minter initially
+			isMinter, err := alchemy.StableCoin.IsMinter(contractHex, otherAddress)
+			assert.Nil(t, err)
+			assert.False(t, isMinter)
+
+			// configure minter with allowance (initAddress is the masterMinter in this test setup)
+			receipt, err := w.StableCoin().ConfigureMinter(context.Background(), contractHex, otherAddress, allowance, nil)
+			assert.Nil(t, err)
+			assert.NotNil(t, receipt)
+
+			// address should now be a minter
+			isMinter, err = alchemy.StableCoin.IsMinter(contractHex, otherAddress)
+			assert.Nil(t, err)
+			assert.True(t, isMinter)
+
+			// allowance should match what was configured
+			minterAllowance, err := alchemy.StableCoin.MinterAllowance(contractHex, otherAddress)
+			assert.Nil(t, err)
+			assert.Equal(t, 0, allowance.Cmp(minterAllowance))
+
+			// remove the minter
+			receipt, err = w.StableCoin().RemoveMinter(context.Background(), contractHex, otherAddress, nil)
+			assert.Nil(t, err)
+			assert.NotNil(t, receipt)
+
+			// address should no longer be a minter
+			isMinter, err = alchemy.StableCoin.IsMinter(contractHex, otherAddress)
+			assert.Nil(t, err)
+			assert.False(t, isMinter)
+		})
 	})
 }
 

--- a/namespace/erc20_namespace.go
+++ b/namespace/erc20_namespace.go
@@ -50,7 +50,7 @@ func (e *ERC20) BalanceOf(
 	output, err := e.ether.CallReadMethod(
 		constant.BalanceOfFnSignature,
 		contractAddress,
-		common.LeftPadBytes(common.HexToAddress(walletAddress).Bytes(), 32),
+		common.LeftPadBytes(common.HexToAddress(walletAddress).Bytes(), constant.ABIWordSize),
 	)
 	if err != nil {
 		return nil, err
@@ -77,8 +77,8 @@ func (e *ERC20) Allowance(contractAddress, owner, spender string) (*big.Int, err
 	output, err := e.ether.CallReadMethod(
 		constant.AllowanceFnSignature,
 		contractAddress,
-		common.LeftPadBytes(common.HexToAddress(owner).Bytes(), 32),
-		common.LeftPadBytes(common.HexToAddress(spender).Bytes(), 32),
+		common.LeftPadBytes(common.HexToAddress(owner).Bytes(), constant.ABIWordSize),
+		common.LeftPadBytes(common.HexToAddress(spender).Bytes(), constant.ABIWordSize),
 	)
 	if err != nil {
 		return nil, err

--- a/namespace/stablecoin_namespace.go
+++ b/namespace/stablecoin_namespace.go
@@ -1,6 +1,8 @@
 package namespace
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/poteto-go/go-alchemy-sdk/constant"
 	"github.com/poteto-go/go-alchemy-sdk/types"
@@ -33,6 +35,12 @@ type IStableCoin interface {
 
 	// Version returns the contract version string.
 	Version(contractAddress string) (string, error)
+
+	// IsMinter returns true if the address is a configured minter.
+	IsMinter(contractAddress, address string) (bool, error)
+
+	// MinterAllowance returns the remaining mint allowance for the given minter.
+	MinterAllowance(contractAddress, address string) (*big.Int, error)
 }
 
 type stableCoin struct {
@@ -122,4 +130,28 @@ func (s *stableCoin) Blacklister(contractAddress string) (common.Address, error)
 		return common.Address{}, err
 	}
 	return utils.DecodeABIAddress(output)
+}
+
+func (s *stableCoin) IsMinter(contractAddress, address string) (bool, error) {
+	output, err := s.ether.CallReadMethod(
+		constant.IsMinterFnSignature,
+		contractAddress,
+		common.LeftPadBytes(common.HexToAddress(address).Bytes(), 32),
+	)
+	if err != nil {
+		return false, err
+	}
+	return decodeBoolOutput(output), nil
+}
+
+func (s *stableCoin) MinterAllowance(contractAddress, address string) (*big.Int, error) {
+	output, err := s.ether.CallReadMethod(
+		constant.MinterAllowanceFnSignature,
+		contractAddress,
+		common.LeftPadBytes(common.HexToAddress(address).Bytes(), 32),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return new(big.Int).SetBytes(output), nil
 }

--- a/namespace/stablecoin_namespace.go
+++ b/namespace/stablecoin_namespace.go
@@ -59,7 +59,7 @@ func (s *stableCoin) IsBlacklisted(contractAddress, address string) (bool, error
 	output, err := s.ether.CallReadMethod(
 		constant.IsBlacklistedFnSignature,
 		contractAddress,
-		common.LeftPadBytes(common.HexToAddress(address).Bytes(), 32),
+		common.LeftPadBytes(common.HexToAddress(address).Bytes(), constant.ABIWordSize),
 	)
 	if err != nil {
 		return false, err
@@ -136,7 +136,7 @@ func (s *stableCoin) IsMinter(contractAddress, address string) (bool, error) {
 	output, err := s.ether.CallReadMethod(
 		constant.IsMinterFnSignature,
 		contractAddress,
-		common.LeftPadBytes(common.HexToAddress(address).Bytes(), 32),
+		common.LeftPadBytes(common.HexToAddress(address).Bytes(), constant.ABIWordSize),
 	)
 	if err != nil {
 		return false, err
@@ -148,7 +148,7 @@ func (s *stableCoin) MinterAllowance(contractAddress, address string) (*big.Int,
 	output, err := s.ether.CallReadMethod(
 		constant.MinterAllowanceFnSignature,
 		contractAddress,
-		common.LeftPadBytes(common.HexToAddress(address).Bytes(), 32),
+		common.LeftPadBytes(common.HexToAddress(address).Bytes(), constant.ABIWordSize),
 	)
 	if err != nil {
 		return nil, err

--- a/namespace/stablecoin_namespace_test.go
+++ b/namespace/stablecoin_namespace_test.go
@@ -375,3 +375,103 @@ func TestStableCoin_Owner(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestStableCoin_IsMinter(t *testing.T) {
+	contractAddress := "0x1234567890abcdef1234567890abcdef12345678"
+	minterAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	t.Run("returns true when address is a minter", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+		expected := make([]byte, 32)
+		expected[31] = 1
+
+		patches.ApplyMethod(reflect.TypeOf(eth), "CallContract", func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+			return expected, nil
+		})
+
+		result, err := sc.IsMinter(contractAddress, minterAddress)
+
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	t.Run("returns false when address is not a minter", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+		expected := make([]byte, 32)
+
+		patches.ApplyMethod(reflect.TypeOf(eth), "CallContract", func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+			return expected, nil
+		})
+
+		result, err := sc.IsMinter(contractAddress, minterAddress)
+
+		assert.NoError(t, err)
+		assert.False(t, result)
+	})
+
+	t.Run("returns error if contract call fails", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		patches.ApplyMethod(reflect.TypeOf(eth), "CallContract", func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+			return nil, assert.AnError
+		})
+
+		result, err := sc.IsMinter(contractAddress, minterAddress)
+
+		assert.Error(t, err)
+		assert.False(t, result)
+	})
+}
+
+func TestStableCoin_MinterAllowance(t *testing.T) {
+	contractAddress := "0x1234567890abcdef1234567890abcdef12345678"
+	minterAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	t.Run("returns minter allowance", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+		expected := make([]byte, 32)
+		expected[31] = 100
+
+		patches.ApplyMethod(reflect.TypeOf(eth), "CallContract", func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+			return expected, nil
+		})
+
+		result, err := sc.MinterAllowance(contractAddress, minterAddress)
+
+		assert.NoError(t, err)
+		assert.Equal(t, int64(100), result.Int64())
+	})
+
+	t.Run("returns error if contract call fails", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		patches.ApplyMethod(reflect.TypeOf(eth), "CallContract", func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+			return nil, assert.AnError
+		})
+
+		result, err := sc.MinterAllowance(contractAddress, minterAddress)
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+}

--- a/wallet/erc20.go
+++ b/wallet/erc20.go
@@ -154,15 +154,15 @@ func (api *walletERC20) sendERC20Tx(contractAddress string, gasLimit *uint64, si
 
 func (api *walletERC20) TransferNoWait(contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
 	return api.sendERC20Tx(contractAddress, gasLimit, constant.TransferFnSignature,
-		common.LeftPadBytes(common.HexToAddress(toAddress).Bytes(), 32),
-		common.LeftPadBytes(amount.Bytes(), 32),
+		common.LeftPadBytes(common.HexToAddress(toAddress).Bytes(), constant.ABIWordSize),
+		common.LeftPadBytes(amount.Bytes(), constant.ABIWordSize),
 	)
 }
 
 func (api *walletERC20) ApproveNoWait(contractAddress, spenderAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
 	return api.sendERC20Tx(contractAddress, gasLimit, constant.ApproveFnSignature,
-		common.LeftPadBytes(common.HexToAddress(spenderAddress).Bytes(), 32),
-		common.LeftPadBytes(amount.Bytes(), 32),
+		common.LeftPadBytes(common.HexToAddress(spenderAddress).Bytes(), constant.ABIWordSize),
+		common.LeftPadBytes(amount.Bytes(), constant.ABIWordSize),
 	)
 }
 
@@ -174,9 +174,9 @@ func (api *walletERC20) Approve(ctx context.Context, contractAddress, spenderAdd
 
 func (api *walletERC20) TransferFromNoWait(contractAddress, fromAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
 	return api.sendERC20Tx(contractAddress, gasLimit, constant.TransferFromFnSignature,
-		common.LeftPadBytes(common.HexToAddress(fromAddress).Bytes(), 32),
-		common.LeftPadBytes(common.HexToAddress(toAddress).Bytes(), 32),
-		common.LeftPadBytes(amount.Bytes(), 32),
+		common.LeftPadBytes(common.HexToAddress(fromAddress).Bytes(), constant.ABIWordSize),
+		common.LeftPadBytes(common.HexToAddress(toAddress).Bytes(), constant.ABIWordSize),
+		common.LeftPadBytes(amount.Bytes(), constant.ABIWordSize),
 	)
 }
 

--- a/wallet/stablecoin.go
+++ b/wallet/stablecoin.go
@@ -195,8 +195,8 @@ type walletStableCoin struct {
 
 func (api *walletStableCoin) MintNoWait(contractAddress, toAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
 	return api.sendERC20Tx(contractAddress, gasLimit, constant.MintFnSignature,
-		common.LeftPadBytes(common.HexToAddress(toAddress).Bytes(), 32),
-		common.LeftPadBytes(amount.Bytes(), 32),
+		common.LeftPadBytes(common.HexToAddress(toAddress).Bytes(), constant.ABIWordSize),
+		common.LeftPadBytes(amount.Bytes(), constant.ABIWordSize),
 	)
 }
 
@@ -208,7 +208,7 @@ func (api *walletStableCoin) Mint(ctx context.Context, contractAddress, toAddres
 
 func (api *walletStableCoin) BurnNoWait(contractAddress string, amount *big.Int, gasLimit *uint64) (common.Hash, error) {
 	return api.sendERC20Tx(contractAddress, gasLimit, constant.BurnFnSignature,
-		common.LeftPadBytes(amount.Bytes(), 32),
+		common.LeftPadBytes(amount.Bytes(), constant.ABIWordSize),
 	)
 }
 
@@ -220,7 +220,7 @@ func (api *walletStableCoin) Burn(ctx context.Context, contractAddress string, a
 
 func (api *walletStableCoin) BlacklistNoWait(contractAddress, address string, gasLimit *uint64) (common.Hash, error) {
 	return api.sendERC20Tx(contractAddress, gasLimit, constant.BlacklistFnSignature,
-		common.LeftPadBytes(common.HexToAddress(address).Bytes(), 32),
+		common.LeftPadBytes(common.HexToAddress(address).Bytes(), constant.ABIWordSize),
 	)
 }
 
@@ -232,7 +232,7 @@ func (api *walletStableCoin) Blacklist(ctx context.Context, contractAddress, add
 
 func (api *walletStableCoin) UnBlacklistNoWait(contractAddress, address string, gasLimit *uint64) (common.Hash, error) {
 	return api.sendERC20Tx(contractAddress, gasLimit, constant.UnBlacklistFnSignature,
-		common.LeftPadBytes(common.HexToAddress(address).Bytes(), 32),
+		common.LeftPadBytes(common.HexToAddress(address).Bytes(), constant.ABIWordSize),
 	)
 }
 
@@ -312,7 +312,7 @@ func (api *walletStableCoin) Paused(contractAddress string) (bool, error) {
 
 func (api *walletStableCoin) TransferOwnershipNoWait(contractAddress, newOwner string, gasLimit *uint64) (common.Hash, error) {
 	return api.sendERC20Tx(contractAddress, gasLimit, constant.TransferOwnershipFnSignature,
-		common.LeftPadBytes(common.HexToAddress(newOwner).Bytes(), 32),
+		common.LeftPadBytes(common.HexToAddress(newOwner).Bytes(), constant.ABIWordSize),
 	)
 }
 
@@ -340,8 +340,8 @@ func (api *walletStableCoin) Version(contractAddress string) (string, error) {
 
 func (api *walletStableCoin) ConfigureMinterNoWait(contractAddress, minter string, allowance *big.Int, gasLimit *uint64) (common.Hash, error) {
 	return api.sendERC20Tx(contractAddress, gasLimit, constant.ConfigureMinterFnSignature,
-		common.LeftPadBytes(common.HexToAddress(minter).Bytes(), 32),
-		common.LeftPadBytes(allowance.Bytes(), 32),
+		common.LeftPadBytes(common.HexToAddress(minter).Bytes(), constant.ABIWordSize),
+		common.LeftPadBytes(allowance.Bytes(), constant.ABIWordSize),
 	)
 }
 
@@ -353,7 +353,7 @@ func (api *walletStableCoin) ConfigureMinter(ctx context.Context, contractAddres
 
 func (api *walletStableCoin) RemoveMinterNoWait(contractAddress, minter string, gasLimit *uint64) (common.Hash, error) {
 	return api.sendERC20Tx(contractAddress, gasLimit, constant.RemoveMinterFnSignature,
-		common.LeftPadBytes(common.HexToAddress(minter).Bytes(), 32),
+		common.LeftPadBytes(common.HexToAddress(minter).Bytes(), constant.ABIWordSize),
 	)
 }
 

--- a/wallet/stablecoin.go
+++ b/wallet/stablecoin.go
@@ -149,6 +149,44 @@ type WalletStableCoin interface {
 		get the contract version string
 	*/
 	Version(contractAddress string) (string, error)
+
+	/*
+		configure a minter with an allowance (requires masterMinter role)
+			- wait for mined
+			- gas limit is 300000 for default
+			- stops waiting when ctx is canceled
+	*/
+	ConfigureMinter(ctx context.Context, contractAddress, minter string, allowance *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error)
+
+	/*
+		configure a minter with an allowance (requires masterMinter role)
+			- gas limit is 300000 for default
+	*/
+	ConfigureMinterNoWait(contractAddress, minter string, allowance *big.Int, gasLimit *uint64) (common.Hash, error)
+
+	/*
+		remove a minter (requires masterMinter role)
+			- wait for mined
+			- gas limit is 300000 for default
+			- stops waiting when ctx is canceled
+	*/
+	RemoveMinter(ctx context.Context, contractAddress, minter string, gasLimit *uint64) (*gethTypes.Receipt, error)
+
+	/*
+		remove a minter (requires masterMinter role)
+			- gas limit is 300000 for default
+	*/
+	RemoveMinterNoWait(contractAddress, minter string, gasLimit *uint64) (common.Hash, error)
+
+	/*
+		check if an address is a configured minter
+	*/
+	IsMinter(contractAddress, address string) (bool, error)
+
+	/*
+		get the remaining mint allowance for a minter
+	*/
+	MinterAllowance(contractAddress, address string) (*big.Int, error)
 }
 
 type walletStableCoin struct {
@@ -298,4 +336,45 @@ func (api *walletStableCoin) Version(contractAddress string) (string, error) {
 		return "", constant.ErrWalletIsNotConnected
 	}
 	return sc.Version(contractAddress)
+}
+
+func (api *walletStableCoin) ConfigureMinterNoWait(contractAddress, minter string, allowance *big.Int, gasLimit *uint64) (common.Hash, error) {
+	return api.sendERC20Tx(contractAddress, gasLimit, constant.ConfigureMinterFnSignature,
+		common.LeftPadBytes(common.HexToAddress(minter).Bytes(), 32),
+		common.LeftPadBytes(allowance.Bytes(), 32),
+	)
+}
+
+func (api *walletStableCoin) ConfigureMinter(ctx context.Context, contractAddress, minter string, allowance *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
+	return api.waitMined(ctx, func() (common.Hash, error) {
+		return api.ConfigureMinterNoWait(contractAddress, minter, allowance, gasLimit)
+	})
+}
+
+func (api *walletStableCoin) RemoveMinterNoWait(contractAddress, minter string, gasLimit *uint64) (common.Hash, error) {
+	return api.sendERC20Tx(contractAddress, gasLimit, constant.RemoveMinterFnSignature,
+		common.LeftPadBytes(common.HexToAddress(minter).Bytes(), 32),
+	)
+}
+
+func (api *walletStableCoin) RemoveMinter(ctx context.Context, contractAddress, minter string, gasLimit *uint64) (*gethTypes.Receipt, error) {
+	return api.waitMined(ctx, func() (common.Hash, error) {
+		return api.RemoveMinterNoWait(contractAddress, minter, gasLimit)
+	})
+}
+
+func (api *walletStableCoin) IsMinter(contractAddress, address string) (bool, error) {
+	sc := api.w.snapshotStableCoin()
+	if sc == nil {
+		return false, constant.ErrWalletIsNotConnected
+	}
+	return sc.IsMinter(contractAddress, address)
+}
+
+func (api *walletStableCoin) MinterAllowance(contractAddress, address string) (*big.Int, error) {
+	sc := api.w.snapshotStableCoin()
+	if sc == nil {
+		return nil, constant.ErrWalletIsNotConnected
+	}
+	return sc.MinterAllowance(contractAddress, address)
 }

--- a/wallet/stablecoin_test.go
+++ b/wallet/stablecoin_test.go
@@ -950,6 +950,283 @@ func TestWallet_StableCoin_TransferOwnershipNoWait(t *testing.T) {
 	})
 }
 
+func TestWallet_StableCoin_ConfigureMinterNoWait(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	minterAddress := "0xE25583099BA105D9ec0A67f5Ae86D90e50036425"
+	expectedHash := common.HexToHash("0x123")
+
+	t.Run("can configure minter", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return expectedHash, nil
+			},
+		)
+
+		hash, err := w.StableCoin().ConfigureMinterNoWait(contractAddress, minterAddress, big.NewInt(1_000_000), nil)
+
+		assert.Nil(t, err)
+		assert.Equal(t, expectedHash, hash)
+	})
+
+	t.Run("handle error on configure minter", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return common.Hash{}, errors.New("error")
+			},
+		)
+
+		_, err := w.StableCoin().ConfigureMinterNoWait(contractAddress, minterAddress, big.NewInt(1_000_000), nil)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.StableCoin().ConfigureMinterNoWait(contractAddress, minterAddress, big.NewInt(1_000_000), nil)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}
+
+func TestWallet_StableCoin_ConfigureMinter(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	minterAddress := "0xE25583099BA105D9ec0A67f5Ae86D90e50036425"
+	expectedHash := common.HexToHash("0x123")
+
+	t.Run("can configure minter and wait", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return expectedHash, nil
+			},
+		)
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"WaitMined",
+			func(_ *ether.Ether, _ context.Context, _ common.Hash) (*gethTypes.Receipt, error) {
+				return &gethTypes.Receipt{}, nil
+			},
+		)
+
+		_, err := w.StableCoin().ConfigureMinter(context.Background(), contractAddress, minterAddress, big.NewInt(1_000_000), nil)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.StableCoin().ConfigureMinter(context.Background(), contractAddress, minterAddress, big.NewInt(1_000_000), nil)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}
+
+func TestWallet_StableCoin_RemoveMinterNoWait(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	minterAddress := "0xE25583099BA105D9ec0A67f5Ae86D90e50036425"
+	expectedHash := common.HexToHash("0x123")
+
+	t.Run("can remove minter", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return expectedHash, nil
+			},
+		)
+
+		hash, err := w.StableCoin().RemoveMinterNoWait(contractAddress, minterAddress, nil)
+
+		assert.Nil(t, err)
+		assert.Equal(t, expectedHash, hash)
+	})
+
+	t.Run("handle error on remove minter", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return common.Hash{}, errors.New("error")
+			},
+		)
+
+		_, err := w.StableCoin().RemoveMinterNoWait(contractAddress, minterAddress, nil)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.StableCoin().RemoveMinterNoWait(contractAddress, minterAddress, nil)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}
+
+func TestWallet_StableCoin_RemoveMinter(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	minterAddress := "0xE25583099BA105D9ec0A67f5Ae86D90e50036425"
+	expectedHash := common.HexToHash("0x123")
+
+	t.Run("can remove minter and wait", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return expectedHash, nil
+			},
+		)
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"WaitMined",
+			func(_ *ether.Ether, _ context.Context, _ common.Hash) (*gethTypes.Receipt, error) {
+				return &gethTypes.Receipt{}, nil
+			},
+		)
+
+		_, err := w.StableCoin().RemoveMinter(context.Background(), contractAddress, minterAddress, nil)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.StableCoin().RemoveMinter(context.Background(), contractAddress, minterAddress, nil)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}
+
+func TestWallet_StableCoin_IsMinter(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	minterAddress := "0xE25583099BA105D9ec0A67f5Ae86D90e50036425"
+
+	t.Run("returns true when address is a minter", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+		expected := make([]byte, 32)
+		expected[31] = 1
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"CallContract",
+			func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+				return expected, nil
+			},
+		)
+
+		result, err := w.StableCoin().IsMinter(contractAddress, minterAddress)
+
+		assert.Nil(t, err)
+		assert.True(t, result)
+	})
+
+	t.Run("returns false when address is not a minter", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+		expected := make([]byte, 32)
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"CallContract",
+			func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+				return expected, nil
+			},
+		)
+
+		result, err := w.StableCoin().IsMinter(contractAddress, minterAddress)
+
+		assert.Nil(t, err)
+		assert.False(t, result)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.StableCoin().IsMinter(contractAddress, minterAddress)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}
+
+func TestWallet_StableCoin_MinterAllowance(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	minterAddress := "0xE25583099BA105D9ec0A67f5Ae86D90e50036425"
+
+	t.Run("returns minter allowance", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+		expected := make([]byte, 32)
+		expected[31] = 100
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"CallContract",
+			func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+				return expected, nil
+			},
+		)
+
+		result, err := w.StableCoin().MinterAllowance(contractAddress, minterAddress)
+
+		assert.Nil(t, err)
+		assert.Equal(t, int64(100), result.Int64())
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.StableCoin().MinterAllowance(contractAddress, minterAddress)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}
+
 func TestWallet_StableCoin_TransferOwnership(t *testing.T) {
 	contractAddress := "0x1234567890123456789012345678901234567890"
 	newOwnerAddress := "0xE25583099BA105D9ec0A67f5Ae86D90e50036425"


### PR DESCRIPTION
## Summary

- Add `IsMinter(address)` and `MinterAllowance(address)` read methods to `IStableCoin` namespace
- Add `ConfigureMinter`/`ConfigureMinterNoWait` and `RemoveMinter`/`RemoveMinterNoWait` write methods to `WalletStableCoin`
- Add 4 new constants for the FiatToken function signatures
- Update e2e test scenario and docs

## Related

closes #369
refs #298

## Test plan

- [x] Unit tests for all new namespace methods (`TestStableCoin_IsMinter`, `TestStableCoin_MinterAllowance`)
- [x] Unit tests for all new wallet methods (`TestWallet_StableCoin_ConfigureMinterNoWait/NoWait`, `TestWallet_StableCoin_RemoveMinter/NoWait`, `TestWallet_StableCoin_IsMinter`, `TestWallet_StableCoin_MinterAllowance`)
- [x] e2e test: configure minter → check `IsMinter` + `MinterAllowance` → remove minter → verify removed
- [x] Docs: `docs/docs/stablecoin-namespace/IsMinter.md`, `MinterAllowance.md`, wallet `StableCoin.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)