### PR TITLE
feat: typed StableCoinSymbol, SupportedNetworks/SupportedSymbols for famous package

### DIFF
--- a/docs/docs/famous/ContractAddress.md
+++ b/docs/docs/famous/ContractAddress.md
@@ -2,16 +2,30 @@
 sidebar_position: 1
 ---
 
-# ContractAddress
+# Famous
 
 `famous` is a helper package that provides contract addresses for well-known stablecoins across supported networks.
+
+## StableCoinSymbol
+
+Typed constant for well-known stablecoin token symbols. Using these constants instead of raw strings prevents typos at compile time.
+
+```go
+type StableCoinSymbol string
+
+const (
+    USDC StableCoinSymbol = "USDC"
+    USDT StableCoinSymbol = "USDT"
+    JPYC StableCoinSymbol = "JPYC"
+)
+```
 
 ## ContractAddress
 
 Returns the contract address of a well-known stablecoin on the given network.
 
 ```go
-func ContractAddress(network types.Network, symbol string) (common.Address, error)
+func ContractAddress(network types.Network, symbol StableCoinSymbol) (common.Address, error)
 ```
 
 ### Supported Tokens
@@ -36,10 +50,44 @@ import (
 )
 
 func main() {
-    addr, err := famous.ContractAddress(types.PolygonMainnet, "JPYC")
+    addr, err := famous.ContractAddress(types.PolygonMainnet, famous.JPYC)
     if err != nil {
         log.Fatal(err)
     }
     fmt.Println(addr.Hex())
+}
+```
+
+## SupportedNetworks
+
+Returns all networks that have at least one registered stablecoin address.
+
+```go
+func SupportedNetworks() []types.Network
+```
+
+### Example
+
+```go
+networks := famous.SupportedNetworks()
+for _, n := range networks {
+    fmt.Println(n)
+}
+```
+
+## SupportedSymbols
+
+Returns all stablecoin symbols registered for the given network. Returns an empty slice if the network is not supported.
+
+```go
+func SupportedSymbols(network types.Network) []StableCoinSymbol
+```
+
+### Example
+
+```go
+symbols := famous.SupportedSymbols(types.EthMainnet)
+for _, s := range symbols {
+    fmt.Println(s)
 }
 ```

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"math/big"
 	"os"
+	"slices"
 	"strconv"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/poteto-go/go-alchemy-sdk/_fixture/artifacts"
 	"github.com/poteto-go/go-alchemy-sdk/deployer"
+	"github.com/poteto-go/go-alchemy-sdk/famous"
 	"github.com/poteto-go/go-alchemy-sdk/gas"
 	"github.com/poteto-go/go-alchemy-sdk/types"
 	"github.com/poteto-go/go-alchemy-sdk/wallet"
@@ -166,6 +168,36 @@ func TestSenario_DeployContract(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Greater(t, blockNumber, uint64(0))
 		})
+	})
+}
+
+func TestScenario_Famous_StableCoin(t *testing.T) {
+	t.Run("SupportedNetworks returns non-empty list including EthMainnet", func(t *testing.T) {
+		networks := famous.SupportedNetworks()
+
+		assert.NotEmpty(t, networks)
+		assert.True(t, slices.Contains(networks, types.EthMainnet))
+	})
+
+	t.Run("SupportedSymbols returns USDC/USDT/JPYC for EthMainnet", func(t *testing.T) {
+		symbols := famous.SupportedSymbols(types.EthMainnet)
+
+		assert.True(t, slices.Contains(symbols, famous.USDC))
+		assert.True(t, slices.Contains(symbols, famous.USDT))
+		assert.True(t, slices.Contains(symbols, famous.JPYC))
+	})
+
+	t.Run("SupportedSymbols returns empty for unsupported network", func(t *testing.T) {
+		symbols := famous.SupportedSymbols(types.SolanaMainnet)
+
+		assert.Empty(t, symbols)
+	})
+
+	t.Run("ContractAddress resolves typed symbol on EthMainnet", func(t *testing.T) {
+		addr, err := famous.ContractAddress(types.EthMainnet, famous.USDC)
+
+		assert.NoError(t, err)
+		assert.Equal(t, common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"), addr)
 	})
 }
 

--- a/famous/stablecoin.go
+++ b/famous/stablecoin.go
@@ -12,26 +12,42 @@ var (
 	ErrNotSupportedSymbol  = errors.New("not supported stablecoin symbol")
 )
 
+// StableCoinSymbol is a typed constant for well-known stablecoin token symbols.
+type StableCoinSymbol string
+
+const (
+	USDC StableCoinSymbol = "USDC"
+	USDT StableCoinSymbol = "USDT"
+	JPYC StableCoinSymbol = "JPYC"
+)
+
 // stablecoinAddresses maps network → token symbol → contract address.
 // Addresses are pre-parsed at init time to avoid repeated hex conversion on each lookup.
-var stablecoinAddresses = map[types.Network]map[string]common.Address{
+var stablecoinAddresses = map[types.Network]map[StableCoinSymbol]common.Address{
 	types.EthMainnet: {
-		"USDC": common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
-		"USDT": common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7"),
-		"JPYC": common.HexToAddress("0x431D5dfF03120AFA4bDf332c61A6e1766eF37BF9"),
+		// https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
+		USDC: common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+		// https://etherscan.io/token/0xdac17f958d2ee523a2206206994597c13d831ec7
+		USDT: common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7"),
+		// https://etherscan.io/token/0x431d5dff03120afa4bdf332c61a6e1766ef37bf9
+		JPYC: common.HexToAddress("0x431D5dfF03120AFA4bDf332c61A6e1766eF37BF9"),
 	},
 	types.PolygonMainnet: {
-		"USDC": common.HexToAddress("0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"),
-		"USDT": common.HexToAddress("0xc2132D05D31c914a87C6611C10748AEb04B58e8F"),
-		"JPYC": common.HexToAddress("0x6AE7Dfc73E0dDE2aa99ac063DcF7e8A63265108c"),
+		// https://polygonscan.com/token/0x3c499c542cef5e3811e1192ce70d8cc03d5c3359 (native USDC)
+		USDC: common.HexToAddress("0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"),
+		// https://polygonscan.com/token/0xc2132d05d31c914a87c6611c10748aeb04b58e8f
+		USDT: common.HexToAddress("0xc2132D05D31c914a87C6611C10748AEb04B58e8F"),
+		// https://polygonscan.com/token/0x6ae7dfc73e0dde2aa99ac063dcf7e8a63265108c
+		JPYC: common.HexToAddress("0x6AE7Dfc73E0dDE2aa99ac063DcF7e8A63265108c"),
 	},
 	types.PolygonAmoy: {
-		"USDC": common.HexToAddress("0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582"),
+		// https://amoy.polygonscan.com/token/0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582 (testnet USDC)
+		USDC: common.HexToAddress("0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582"),
 	},
 }
 
 // ContractAddress returns the contract address of a well-known stablecoin on the given network.
-func ContractAddress(network types.Network, symbol string) (common.Address, error) {
+func ContractAddress(network types.Network, symbol StableCoinSymbol) (common.Address, error) {
 	networkMap, ok := stablecoinAddresses[network]
 	if !ok {
 		return common.Address{}, ErrNotSupportedNetwork
@@ -43,4 +59,28 @@ func ContractAddress(network types.Network, symbol string) (common.Address, erro
 	}
 
 	return addr, nil
+}
+
+// SupportedNetworks returns all networks that have at least one registered stablecoin address.
+func SupportedNetworks() []types.Network {
+	networks := make([]types.Network, 0, len(stablecoinAddresses))
+	for n := range stablecoinAddresses {
+		networks = append(networks, n)
+	}
+	return networks
+}
+
+// SupportedSymbols returns all stablecoin symbols registered for the given network.
+// Returns an empty slice if the network is not supported.
+func SupportedSymbols(network types.Network) []StableCoinSymbol {
+	networkMap, ok := stablecoinAddresses[network]
+	if !ok {
+		return nil
+	}
+
+	symbols := make([]StableCoinSymbol, 0, len(networkMap))
+	for s := range networkMap {
+		symbols = append(symbols, s)
+	}
+	return symbols
 }

--- a/famous/stablecoin_test.go
+++ b/famous/stablecoin_test.go
@@ -1,6 +1,8 @@
 package famous_test
 
 import (
+	"slices"
+	"sort"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -10,46 +12,46 @@ import (
 )
 
 func TestContractAddress(t *testing.T) {
-	t.Run("returns known addresses", func(t *testing.T) {
+	t.Run("returns known addresses using typed symbols", func(t *testing.T) {
 		tests := []struct {
 			name    string
 			network types.Network
-			symbol  string
+			symbol  famous.StableCoinSymbol
 			want    common.Address
 		}{
 			{
 				"USDC on Ethereum mainnet",
-				types.EthMainnet, "USDC",
+				types.EthMainnet, famous.USDC,
 				common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
 			},
 			{
 				"USDT on Ethereum mainnet",
-				types.EthMainnet, "USDT",
+				types.EthMainnet, famous.USDT,
 				common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7"),
 			},
 			{
 				"JPYC on Ethereum mainnet",
-				types.EthMainnet, "JPYC",
+				types.EthMainnet, famous.JPYC,
 				common.HexToAddress("0x431D5dfF03120AFA4bDf332c61A6e1766eF37BF9"),
 			},
 			{
 				"USDC on Polygon mainnet",
-				types.PolygonMainnet, "USDC",
+				types.PolygonMainnet, famous.USDC,
 				common.HexToAddress("0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"),
 			},
 			{
 				"USDT on Polygon mainnet",
-				types.PolygonMainnet, "USDT",
+				types.PolygonMainnet, famous.USDT,
 				common.HexToAddress("0xc2132D05D31c914a87C6611C10748AEb04B58e8F"),
 			},
 			{
 				"JPYC on Polygon mainnet",
-				types.PolygonMainnet, "JPYC",
+				types.PolygonMainnet, famous.JPYC,
 				common.HexToAddress("0x6AE7Dfc73E0dDE2aa99ac063DcF7e8A63265108c"),
 			},
 			{
 				"USDC on Polygon Amoy",
-				types.PolygonAmoy, "USDC",
+				types.PolygonAmoy, famous.USDC,
 				common.HexToAddress("0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582"),
 			},
 		}
@@ -65,7 +67,7 @@ func TestContractAddress(t *testing.T) {
 	})
 
 	t.Run("returns error for unsupported network", func(t *testing.T) {
-		_, err := famous.ContractAddress(types.SolanaMainnet, "USDC")
+		_, err := famous.ContractAddress(types.SolanaMainnet, famous.USDC)
 
 		assert.ErrorIs(t, err, famous.ErrNotSupportedNetwork)
 	})
@@ -74,5 +76,41 @@ func TestContractAddress(t *testing.T) {
 		_, err := famous.ContractAddress(types.EthMainnet, "UNKNOWN")
 
 		assert.ErrorIs(t, err, famous.ErrNotSupportedSymbol)
+	})
+}
+
+func TestSupportedNetworks(t *testing.T) {
+	networks := famous.SupportedNetworks()
+
+	assert.NotEmpty(t, networks)
+	assert.True(t, slices.Contains(networks, types.EthMainnet))
+	assert.True(t, slices.Contains(networks, types.PolygonMainnet))
+	assert.True(t, slices.Contains(networks, types.PolygonAmoy))
+}
+
+func TestSupportedSymbols(t *testing.T) {
+	t.Run("returns symbols for EthMainnet", func(t *testing.T) {
+		symbols := famous.SupportedSymbols(types.EthMainnet)
+
+		got := make([]string, len(symbols))
+		for i, s := range symbols {
+			got[i] = string(s)
+		}
+		sort.Strings(got)
+
+		assert.Equal(t, []string{"JPYC", "USDC", "USDT"}, got)
+	})
+
+	t.Run("returns symbols for PolygonAmoy", func(t *testing.T) {
+		symbols := famous.SupportedSymbols(types.PolygonAmoy)
+
+		assert.Len(t, symbols, 1)
+		assert.Equal(t, famous.USDC, symbols[0])
+	})
+
+	t.Run("returns empty slice for unsupported network", func(t *testing.T) {
+		symbols := famous.SupportedSymbols(types.SolanaMainnet)
+
+		assert.Empty(t, symbols)
 	})
 }


### PR DESCRIPTION
Closes #385 (L2 support excluded — to be added when demand arises)

## Summary

- Add `StableCoinSymbol` typed string constant (`USDC`, `USDT`, `JPYC`) so callers get compile-time typo detection instead of raw `string`
- Update `ContractAddress` signature: `symbol string` → `symbol StableCoinSymbol`
- Add `SupportedNetworks() []types.Network` — list all networks with registered addresses
- Add `SupportedSymbols(network) []StableCoinSymbol` — list symbols available on a given network
- Add Etherscan/Polygonscan source comments to each hardcoded address

## Test plan

- [x] All existing `TestContractAddress` cases updated to use typed constants — still pass
- [x] New `TestSupportedNetworks` and `TestSupportedSymbols` unit tests added (TDD: red → green)
- [x] e2e `TestScenario_Famous_StableCoin` added covering both listing helpers and `ContractAddress`
- [x] `/docs` updated with `StableCoinSymbol`, `SupportedNetworks`, `SupportedSymbols` API docs
- [x] `just ut` passes — all packages green

🤖 Generated with [Claude Code](https://claude.com/claude-code)