### PR TITLE
fix: validate contractAddress and address args in namespace read/write methods

### DIFF
--- a/namespace/erc20_namespace.go
+++ b/namespace/erc20_namespace.go
@@ -8,6 +8,7 @@ import (
 	"github.com/poteto-go/go-alchemy-sdk/constant"
 	"github.com/poteto-go/go-alchemy-sdk/types"
 	"github.com/poteto-go/go-alchemy-sdk/utils"
+	"github.com/poteto-go/go-alchemy-sdk/validate"
 )
 
 type IERC20 interface {
@@ -47,6 +48,9 @@ func (e *ERC20) BalanceOf(
 	contractAddress,
 	walletAddress string,
 ) (*big.Int, error) {
+	if err := validate.Addresses(contractAddress, walletAddress); err != nil {
+		return nil, err
+	}
 	output, err := e.ether.CallReadMethod(
 		constant.BalanceOfFnSignature,
 		contractAddress,
@@ -61,6 +65,9 @@ func (e *ERC20) BalanceOf(
 }
 
 func (e *ERC20) TotalSupply(contractAddress string) (*big.Int, error) {
+	if err := validate.Address(contractAddress); err != nil {
+		return nil, err
+	}
 	output, err := e.ether.CallReadMethod(
 		constant.TotalSupplyFnSignature,
 		contractAddress,
@@ -74,6 +81,9 @@ func (e *ERC20) TotalSupply(contractAddress string) (*big.Int, error) {
 }
 
 func (e *ERC20) Allowance(contractAddress, owner, spender string) (*big.Int, error) {
+	if err := validate.Addresses(contractAddress, owner, spender); err != nil {
+		return nil, err
+	}
 	output, err := e.ether.CallReadMethod(
 		constant.AllowanceFnSignature,
 		contractAddress,
@@ -89,6 +99,9 @@ func (e *ERC20) Allowance(contractAddress, owner, spender string) (*big.Int, err
 }
 
 func (e *ERC20) Name(contractAddress string) (string, error) {
+	if err := validate.Address(contractAddress); err != nil {
+		return "", err
+	}
 	output, err := e.ether.CallReadMethod(
 		constant.NameFnSignature,
 		contractAddress,
@@ -101,6 +114,9 @@ func (e *ERC20) Name(contractAddress string) (string, error) {
 }
 
 func (e *ERC20) Symbol(contractAddress string) (string, error) {
+	if err := validate.Address(contractAddress); err != nil {
+		return "", err
+	}
 	output, err := e.ether.CallReadMethod(
 		constant.SymbolFnSignature,
 		contractAddress,
@@ -113,6 +129,9 @@ func (e *ERC20) Symbol(contractAddress string) (string, error) {
 }
 
 func (e *ERC20) Decimals(contractAddress string) (uint8, error) {
+	if err := validate.Address(contractAddress); err != nil {
+		return 0, err
+	}
 	output, err := e.ether.CallReadMethod(
 		constant.DecimalsFnSignature,
 		contractAddress,

--- a/namespace/erc20_namespace_test.go
+++ b/namespace/erc20_namespace_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/agiledragon/gomonkey"
 	"github.com/ethereum/go-ethereum"
+	"github.com/poteto-go/go-alchemy-sdk/constant"
 	"github.com/poteto-go/go-alchemy-sdk/ether"
 	"github.com/poteto-go/go-alchemy-sdk/namespace"
 	"github.com/poteto-go/go-alchemy-sdk/utils"
@@ -62,6 +63,24 @@ func TestERC20_BalanceOf(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, balance)
 	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		erc20 := namespace.NewERC20Namespace(eth)
+
+		_, err := erc20.BalanceOf("invalid", walletAddress)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
+
+	t.Run("returns error for invalid walletAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		erc20 := namespace.NewERC20Namespace(eth)
+
+		_, err := erc20.BalanceOf(contractAddress, "invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
 }
 
 func TestERC20_TotalSupply(t *testing.T) {
@@ -96,12 +115,21 @@ func TestERC20_TotalSupply(t *testing.T) {
 		_, err := erc20.TotalSupply(contractAddress)
 		assert.Error(t, err)
 	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		erc20 := namespace.NewERC20Namespace(eth)
+
+		_, err := erc20.TotalSupply("invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
 }
 
 func TestERC20_Allowance(t *testing.T) {
 	contractAddress := "0x1234567890abcdef1234567890abcdef12345678"
-	owner := "0xowner"
-	spender := "0xspender"
+	owner := "0xabcdef1234567890abcdef1234567890abcdef12"
+	spender := "0x1234567890abcdef1234567890abcdef12345678"
 
 	t.Run("can get allowance", func(t *testing.T) {
 		patches := gomonkey.NewPatches()
@@ -131,6 +159,33 @@ func TestERC20_Allowance(t *testing.T) {
 
 		_, err := erc20.Allowance(contractAddress, owner, spender)
 		assert.Error(t, err)
+	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		erc20 := namespace.NewERC20Namespace(eth)
+
+		_, err := erc20.Allowance("invalid", owner, spender)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
+
+	t.Run("returns error for invalid owner", func(t *testing.T) {
+		eth := newEtherApi()
+		erc20 := namespace.NewERC20Namespace(eth)
+
+		_, err := erc20.Allowance(contractAddress, "invalid", spender)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
+
+	t.Run("returns error for invalid spender", func(t *testing.T) {
+		eth := newEtherApi()
+		erc20 := namespace.NewERC20Namespace(eth)
+
+		_, err := erc20.Allowance(contractAddress, owner, "invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
 	})
 }
 
@@ -166,6 +221,15 @@ func TestERC20_Name(t *testing.T) {
 		_, err := erc20.Name(contractAddress)
 		assert.Error(t, err)
 	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		erc20 := namespace.NewERC20Namespace(eth)
+
+		_, err := erc20.Name("invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
 }
 
 func TestERC20_Symbol(t *testing.T) {
@@ -199,6 +263,15 @@ func TestERC20_Symbol(t *testing.T) {
 
 		_, err := erc20.Symbol(contractAddress)
 		assert.Error(t, err)
+	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		erc20 := namespace.NewERC20Namespace(eth)
+
+		_, err := erc20.Symbol("invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
 	})
 }
 
@@ -249,5 +322,14 @@ func TestERC20_Decimals(t *testing.T) {
 
 		_, err := erc20.Decimals(contractAddress)
 		assert.Error(t, err)
+	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		erc20 := namespace.NewERC20Namespace(eth)
+
+		_, err := erc20.Decimals("invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
 	})
 }

--- a/namespace/stablecoin_namespace.go
+++ b/namespace/stablecoin_namespace.go
@@ -8,6 +8,7 @@ import (
 	"github.com/poteto-go/go-alchemy-sdk/constant"
 	"github.com/poteto-go/go-alchemy-sdk/types"
 	"github.com/poteto-go/go-alchemy-sdk/utils"
+	"github.com/poteto-go/go-alchemy-sdk/validate"
 )
 
 type IStableCoin interface {
@@ -63,6 +64,9 @@ func decodeBoolOutput(output []byte) bool {
 }
 
 func (s *stableCoin) IsBlacklisted(contractAddress, address string) (bool, error) {
+	if err := validate.Addresses(contractAddress, address); err != nil {
+		return false, err
+	}
 	output, err := s.ether.CallReadMethod(
 		constant.IsBlacklistedFnSignature,
 		contractAddress,
@@ -75,6 +79,9 @@ func (s *stableCoin) IsBlacklisted(contractAddress, address string) (bool, error
 }
 
 func (s *stableCoin) Currency(contractAddress string) (string, error) {
+	if err := validate.Address(contractAddress); err != nil {
+		return "", err
+	}
 	output, err := s.ether.CallReadMethod(
 		constant.CurrencyFnSignature,
 		contractAddress,
@@ -86,6 +93,9 @@ func (s *stableCoin) Currency(contractAddress string) (string, error) {
 }
 
 func (s *stableCoin) Version(contractAddress string) (string, error) {
+	if err := validate.Address(contractAddress); err != nil {
+		return "", err
+	}
 	output, err := s.ether.CallReadMethod(
 		constant.VersionFnSignature,
 		contractAddress,
@@ -97,6 +107,9 @@ func (s *stableCoin) Version(contractAddress string) (string, error) {
 }
 
 func (s *stableCoin) Paused(contractAddress string) (bool, error) {
+	if err := validate.Address(contractAddress); err != nil {
+		return false, err
+	}
 	output, err := s.ether.CallReadMethod(
 		constant.PausedFnSignature,
 		contractAddress,
@@ -108,6 +121,9 @@ func (s *stableCoin) Paused(contractAddress string) (bool, error) {
 }
 
 func (s *stableCoin) Owner(contractAddress string) (common.Address, error) {
+	if err := validate.Address(contractAddress); err != nil {
+		return common.Address{}, err
+	}
 	output, err := s.ether.CallReadMethod(constant.OwnerFnSignature, contractAddress)
 	if err != nil {
 		return common.Address{}, err
@@ -116,6 +132,9 @@ func (s *stableCoin) Owner(contractAddress string) (common.Address, error) {
 }
 
 func (s *stableCoin) MasterMinter(contractAddress string) (common.Address, error) {
+	if err := validate.Address(contractAddress); err != nil {
+		return common.Address{}, err
+	}
 	output, err := s.ether.CallReadMethod(constant.MasterMinterFnSignature, contractAddress)
 	if err != nil {
 		return common.Address{}, err
@@ -124,6 +143,9 @@ func (s *stableCoin) MasterMinter(contractAddress string) (common.Address, error
 }
 
 func (s *stableCoin) Pauser(contractAddress string) (common.Address, error) {
+	if err := validate.Address(contractAddress); err != nil {
+		return common.Address{}, err
+	}
 	output, err := s.ether.CallReadMethod(constant.PauserFnSignature, contractAddress)
 	if err != nil {
 		return common.Address{}, err
@@ -132,6 +154,9 @@ func (s *stableCoin) Pauser(contractAddress string) (common.Address, error) {
 }
 
 func (s *stableCoin) Blacklister(contractAddress string) (common.Address, error) {
+	if err := validate.Address(contractAddress); err != nil {
+		return common.Address{}, err
+	}
 	output, err := s.ether.CallReadMethod(constant.BlacklisterFnSignature, contractAddress)
 	if err != nil {
 		return common.Address{}, err
@@ -140,6 +165,9 @@ func (s *stableCoin) Blacklister(contractAddress string) (common.Address, error)
 }
 
 func (s *stableCoin) IsMinter(contractAddress, address string) (bool, error) {
+	if err := validate.Addresses(contractAddress, address); err != nil {
+		return false, err
+	}
 	output, err := s.ether.CallReadMethod(
 		constant.IsMinterFnSignature,
 		contractAddress,
@@ -152,6 +180,9 @@ func (s *stableCoin) IsMinter(contractAddress, address string) (bool, error) {
 }
 
 func (s *stableCoin) MinterAllowance(contractAddress, address string) (*big.Int, error) {
+	if err := validate.Addresses(contractAddress, address); err != nil {
+		return nil, err
+	}
 	output, err := s.ether.CallReadMethod(
 		constant.MinterAllowanceFnSignature,
 		contractAddress,
@@ -164,6 +195,9 @@ func (s *stableCoin) MinterAllowance(contractAddress, address string) (*big.Int,
 }
 
 func (s *stableCoin) Nonces(contractAddress, ownerAddress string) (*big.Int, error) {
+	if err := validate.Addresses(contractAddress, ownerAddress); err != nil {
+		return nil, err
+	}
 	output, err := s.ether.CallReadMethod(
 		constant.NoncesFnSignature,
 		contractAddress,
@@ -176,6 +210,9 @@ func (s *stableCoin) Nonces(contractAddress, ownerAddress string) (*big.Int, err
 }
 
 func (s *stableCoin) DomainSeparator(contractAddress string) ([32]byte, error) {
+	if err := validate.Address(contractAddress); err != nil {
+		return [32]byte{}, err
+	}
 	output, err := s.ether.CallReadMethod(
 		constant.DomainSeparatorFnSignature,
 		contractAddress,

--- a/namespace/stablecoin_namespace_test.go
+++ b/namespace/stablecoin_namespace_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/agiledragon/gomonkey"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/poteto-go/go-alchemy-sdk/constant"
 	"github.com/poteto-go/go-alchemy-sdk/ether"
 	"github.com/poteto-go/go-alchemy-sdk/namespace"
 	"github.com/poteto-go/go-alchemy-sdk/utils"
@@ -78,6 +79,24 @@ func TestStableCoin_IsBlacklisted(t *testing.T) {
 		assert.Error(t, err)
 		assert.False(t, result)
 	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.IsBlacklisted("invalid", walletAddress)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
+
+	t.Run("returns error for invalid address", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.IsBlacklisted(contractAddress, "invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
 }
 
 func TestStableCoin_Currency(t *testing.T) {
@@ -117,6 +136,15 @@ func TestStableCoin_Currency(t *testing.T) {
 		assert.Error(t, err)
 		assert.Empty(t, result)
 	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.Currency("invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
 }
 
 func TestStableCoin_Version(t *testing.T) {
@@ -155,6 +183,15 @@ func TestStableCoin_Version(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Empty(t, result)
+	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.Version("invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
 	})
 }
 
@@ -214,6 +251,15 @@ func TestStableCoin_Paused(t *testing.T) {
 		assert.Error(t, err)
 		assert.False(t, result)
 	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.Paused("invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
 }
 
 func TestStableCoin_MasterMinter(t *testing.T) {
@@ -253,6 +299,15 @@ func TestStableCoin_MasterMinter(t *testing.T) {
 		_, err := sc.MasterMinter(contractAddress)
 
 		assert.Error(t, err)
+	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.MasterMinter("invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
 	})
 }
 
@@ -294,6 +349,15 @@ func TestStableCoin_Pauser(t *testing.T) {
 
 		assert.Error(t, err)
 	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.Pauser("invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
 }
 
 func TestStableCoin_Blacklister(t *testing.T) {
@@ -334,6 +398,15 @@ func TestStableCoin_Blacklister(t *testing.T) {
 
 		assert.Error(t, err)
 	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.Blacklister("invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
 }
 
 func TestStableCoin_Owner(t *testing.T) {
@@ -373,6 +446,15 @@ func TestStableCoin_Owner(t *testing.T) {
 		_, err := sc.Owner(contractAddress)
 
 		assert.Error(t, err)
+	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.Owner("invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
 	})
 }
 
@@ -433,6 +515,24 @@ func TestStableCoin_IsMinter(t *testing.T) {
 		assert.Error(t, err)
 		assert.False(t, result)
 	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.IsMinter("invalid", minterAddress)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
+
+	t.Run("returns error for invalid address", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.IsMinter(contractAddress, "invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
 }
 
 func TestStableCoin_MinterAllowance(t *testing.T) {
@@ -473,6 +573,24 @@ func TestStableCoin_MinterAllowance(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, result)
+	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.MinterAllowance("invalid", minterAddress)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
+
+	t.Run("returns error for invalid address", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.MinterAllowance(contractAddress, "invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
 	})
 }
 
@@ -532,6 +650,24 @@ func TestStableCoin_Nonces(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, result)
 	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.Nonces("invalid", ownerAddress)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
+
+	t.Run("returns error for invalid ownerAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.Nonces(contractAddress, "invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
 }
 
 func TestStableCoin_DomainSeparator(t *testing.T) {
@@ -589,5 +725,14 @@ func TestStableCoin_DomainSeparator(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Equal(t, [32]byte{}, result)
+	})
+
+	t.Run("returns error for invalid contractAddress", func(t *testing.T) {
+		eth := newEtherApi()
+		sc := namespace.NewStableCoinNamespace(eth)
+
+		_, err := sc.DomainSeparator("invalid")
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
 	})
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -26,3 +26,12 @@ func Address(addr string) error {
 	}
 	return nil
 }
+
+func Addresses(addrs ...string) error {
+	for _, addr := range addrs {
+		if err := Address(addr); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -58,3 +58,25 @@ func TestAddress(t *testing.T) {
 		})
 	}
 }
+
+func TestAddresses(t *testing.T) {
+	valid := "0xE25583099BA105D9ec0A67f5Ae86D90e50036425"
+	invalid := "invalid"
+
+	tests := []struct {
+		name    string
+		addrs   []string
+		wantErr error
+	}{
+		{"all valid", []string{valid, valid}, nil},
+		{"first invalid", []string{invalid, valid}, constant.ErrInvalidAddress},
+		{"second invalid", []string{valid, invalid}, constant.ErrInvalidAddress},
+		{"empty slice", []string{}, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ErrorIs(t, validate.Addresses(tt.addrs...), tt.wantErr)
+		})
+	}
+}

--- a/wallet/erc20.go
+++ b/wallet/erc20.go
@@ -60,6 +60,9 @@ func resolveGasLimit(gasLimit *uint64) uint64 {
 }
 
 func (api *walletERC20) sendERC20Tx(contractAddress string, gasLimit *uint64, sig []byte, params ...[]byte) (common.Hash, error) {
+	if err := validateAddress(contractAddress); err != nil {
+		return common.Hash{}, err
+	}
 	if api.w.snapshot() == nil {
 		return common.Hash{}, constant.ErrWalletIsNotConnected
 	}

--- a/wallet/erc20_test.go
+++ b/wallet/erc20_test.go
@@ -258,6 +258,14 @@ func TestWallet_ERC20TransferNoWait(t *testing.T) {
 		// Assert
 		assert.Error(t, err)
 	})
+
+	t.Run("invalid contractAddress returns ErrInvalidAddress", func(t *testing.T) {
+		w := createConnectedWallet()
+
+		_, err := w.ERC20().TransferNoWait("invalid", otherAddress, big.NewInt(1), nil)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
 }
 
 func TestWallet_ERC20Approve(t *testing.T) {
@@ -387,6 +395,14 @@ func TestWallet_ERC20ApproveNoWait(t *testing.T) {
 		_, err := w.ERC20().ApproveNoWait(contractAddress, spenderAddress, nil, nil)
 
 		assert.ErrorIs(t, err, constant.ErrNilAmount)
+	})
+
+	t.Run("invalid contractAddress returns ErrInvalidAddress", func(t *testing.T) {
+		w := createConnectedWallet()
+
+		_, err := w.ERC20().ApproveNoWait("invalid", spenderAddress, big.NewInt(1), nil)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
 	})
 }
 
@@ -527,6 +543,14 @@ func TestWallet_ERC20TransferFromNoWait(t *testing.T) {
 		_, err := w.ERC20().TransferFromNoWait(contractAddress, fromAddress, toAddress, nil, nil)
 
 		assert.ErrorIs(t, err, constant.ErrNilAmount)
+	})
+
+	t.Run("invalid contractAddress returns ErrInvalidAddress", func(t *testing.T) {
+		w := createConnectedWallet()
+
+		_, err := w.ERC20().TransferFromNoWait("invalid", fromAddress, toAddress, big.NewInt(1), nil)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
 	})
 }
 

--- a/wallet/stablecoin_test.go
+++ b/wallet/stablecoin_test.go
@@ -79,6 +79,14 @@ func TestWallet_StableCoin_MintNoWait(t *testing.T) {
 
 		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
 	})
+
+	t.Run("invalid contractAddress returns ErrInvalidAddress", func(t *testing.T) {
+		w := createConnectedWallet()
+
+		_, err := w.StableCoin().MintNoWait("invalid", toAddress, big.NewInt(100), nil)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
 }
 
 func TestWallet_StableCoin_Mint(t *testing.T) {
@@ -170,6 +178,14 @@ func TestWallet_StableCoin_BurnNoWait(t *testing.T) {
 		_, err := w.StableCoin().BurnNoWait(contractAddress, big.NewInt(50), nil)
 
 		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+
+	t.Run("invalid contractAddress returns ErrInvalidAddress", func(t *testing.T) {
+		w := createConnectedWallet()
+
+		_, err := w.StableCoin().BurnNoWait("invalid", big.NewInt(50), nil)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
 	})
 }
 


### PR DESCRIPTION
## Summary

Closes #398

- Add `validate.Addresses(addrs ...string) error` variadic helper to `validate/validate.go` for concise multi-address validation
- Apply address validation to all `contractAddress` / `walletAddress` / `owner` / `spender` / `address` params in `ERC20` and `StableCoin` namespace read methods — prevents silent zero-address coercion via `common.HexToAddress`
- Apply `validateAddress(contractAddress)` in `walletERC20.sendERC20Tx` so all ERC20 and StableCoin write paths reject invalid contract addresses before sending a transaction

## Test plan

- [ ] `go test ./validate/... -gcflags=all=-l` — new `TestAddresses` covers the variadic helper
- [ ] `go test ./namespace/... -gcflags=all=-l` — new `"returns error for invalid X"` subtests cover every guarded param in both `ERC20` and `StableCoin` namespace methods
- [ ] `go test ./wallet/... -gcflags=all=-l` — new `"invalid contractAddress returns ErrInvalidAddress"` subtests cover `TransferNoWait`, `ApproveNoWait`, `TransferFromNoWait`, `MintNoWait`, `BurnNoWait`

🤖 Generated with [Claude Code](https://claude.com/claude-code)