### PR TITLE
fix: retry transient url.Error (timeout/deadline) (#396)

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/url"
@@ -23,7 +24,10 @@ func isAlwaysReProduceError(err error) bool {
 		return false
 	}
 
-	if _, ok := errors.AsType[*url.Error](err); ok {
+	if urlErr, ok := errors.AsType[*url.Error](err); ok {
+		if urlErr.Timeout() || errors.Is(urlErr.Err, context.DeadlineExceeded) {
+			return false
+		}
 		return true
 	}
 

--- a/internal/errors_test.go
+++ b/internal/errors_test.go
@@ -1,7 +1,9 @@
 package internal
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -35,9 +37,23 @@ func Test_isAlwaysReproduceError(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "url error",
+			name:     "url error - permanent (no timeout)",
 			err:      &url.Error{},
 			expected: true,
+		},
+		{
+			name:     "url error - timeout",
+			err:      &url.Error{Op: "Get", URL: "https://example.com", Err: context.DeadlineExceeded},
+			expected: false,
+		},
+		{
+			name: "url error - wrapped deadline exceeded",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://example.com",
+				Err: fmt.Errorf("wrapped: %w", context.DeadlineExceeded),
+			},
+			expected: false,
 		},
 		{
 			name:     "http.StatusTooManyRequests",


### PR DESCRIPTION
## Summary

- `isAlwaysReProduceError` was classifying all `*url.Error` as non-retryable, causing transient network failures (timeouts, deadline exceeded) to bypass the backoff retry logic entirely
- Now only returns `true` (non-retryable) for `url.Error` cases without a timeout — e.g. invalid URL
- Timeout-flavored `url.Error` (`Timeout() == true` or wrapping `context.DeadlineExceeded`) return `false` so the backoff in `requestWithBackoff` can kick in

## Test plan

- [x] `url error - permanent (no timeout)` → still non-retryable (`true`)
- [x] `url error - timeout` (`url.Error` wrapping `context.DeadlineExceeded` directly) → retryable (`false`)
- [x] `url error - wrapped deadline exceeded` (`url.Error` wrapping `fmt.Errorf("…: %w", context.DeadlineExceeded)`) → retryable (`false`)
- [x] All existing tests pass

closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)