### PR TITLE
perf(wallet): release lock during chainID/gasPrice RPC and cache chainID in SignTx (#397)

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -155,7 +155,7 @@ func (w *wallet) SignTx(txRequest types.TransactionRequest) (*gethTypes.Transact
 		txRequest.GasPrice = gasPrice
 	}
 
-	chainID, err := provider.Eth().ChainID()
+	chainID, _, err := w.chainID()
 	if err != nil {
 		return nil, err
 	}
@@ -303,22 +303,15 @@ func (w *wallet) StableCoin() types.WalletStableCoin {
 }
 
 func (w *wallet) buildAuth() (*bind.TransactOpts, error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	if w.cachedChainID == nil {
-		chainID, err := w.provider.Eth().ChainID()
-		if err != nil {
-			return nil, err
-		}
-		w.cachedChainID = chainID
-		w.legacyChain = slices.Contains(internal.ChainListNotSupportEIP1559, chainID.Int64())
+	chainID, legacyChain, err := w.chainID()
+	if err != nil {
+		return nil, err
 	}
 
-	auth := bind.NewKeyedTransactor(w.privateKey, w.cachedChainID)
+	auth := bind.NewKeyedTransactor(w.privateKey, chainID)
 
-	if w.legacyChain {
-		gasPrice, err := w.provider.Eth().SuggestGasPrice()
+	if legacyChain {
+		gasPrice, err := w.snapshot().Eth().SuggestGasPrice()
 		if err != nil {
 			return nil, err
 		}
@@ -326,6 +319,41 @@ func (w *wallet) buildAuth() (*bind.TransactOpts, error) {
 	}
 
 	return auth, nil
+}
+
+// chainID returns the cached chainID and legacy-chain flag, fetching them from
+// the network on first use. It uses a double-checked pattern so the network
+// round-trip happens outside the lock: a concurrent buildAuth / SignTx no longer
+// blocks on the write lock for the duration of the RPC.
+func (w *wallet) chainID() (*big.Int, bool, error) {
+	w.mu.RLock()
+	if w.cachedChainID != nil {
+		chainID, legacyChain := w.cachedChainID, w.legacyChain
+		w.mu.RUnlock()
+		return chainID, legacyChain, nil
+	}
+	provider := w.provider
+	w.mu.RUnlock()
+
+	if provider == nil {
+		return nil, false, constant.ErrWalletIsNotConnected
+	}
+
+	chainID, err := provider.Eth().ChainID()
+	if err != nil {
+		return nil, false, err
+	}
+	legacyChain := slices.Contains(internal.ChainListNotSupportEIP1559, chainID.Int64())
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	// Another goroutine may have populated the cache while we were fetching;
+	// prefer the already-cached value so all callers observe the same chainID.
+	if w.cachedChainID == nil {
+		w.cachedChainID = chainID
+		w.legacyChain = legacyChain
+	}
+	return w.cachedChainID, w.legacyChain, nil
 }
 
 func (w *wallet) ResetPool() {

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1676,6 +1676,58 @@ func TestWallet_buildAuth(t *testing.T) {
 	})
 }
 
+func TestWallet_SignTx_CachesChainID(t *testing.T) {
+	t.Run("ChainID RPC is called only once across multiple SignTx calls", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+		txRequest := types.TransactionRequest{
+			To:       "0x123",
+			Nonce:    0,
+			GasLimit: 1000,
+			Value:    "0x123",
+			Data:     []byte("0x123"),
+		}
+		chainIDCallCount := 0
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"PendingNonceAt",
+			func(_ *wallet) (uint64, error) { return 0, nil },
+		)
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"EstimateGas",
+			func(_ *ether.Ether, _ types.TransactionRequest) (*big.Int, error) {
+				return big.NewInt(100), nil
+			},
+		)
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"SuggestGasPrice",
+			func(_ *ether.Ether) (*big.Int, error) {
+				return big.NewInt(1_000_000_000), nil
+			},
+		)
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"ChainID",
+			func(_ *ether.Ether) (*big.Int, error) {
+				chainIDCallCount++
+				return big.NewInt(1), nil
+			},
+		)
+
+		_, err := w.SignTx(txRequest)
+		assert.NoError(t, err)
+		_, err = w.SignTx(txRequest)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 1, chainIDCallCount, "ChainID RPC must be called only once (cached)")
+	})
+}
+
 func TestWallet_ResetPool(t *testing.T) {
 	txData := &gethTypes.AccessListTx{
 		To:       &common.Address{},


### PR DESCRIPTION
## 概要

`wallet` パッケージのトランザクション系メソッドのロック競合・RPC直列化を解消します。closes: #397

## 変更点

### 1. `buildAuth` がロック保持中にネットワークI/Oする問題
排他ロック (`w.mu.Lock()`) を ChainID / SuggestGasPrice のネットワーク往復の間ずっと保持していたため、`DeployContractNoWait` / `ContractTransactNoWait` の並行実行が互いにブロックしていました。

ChainID キャッシュ処理を共有ヘルパー `chainID()` に切り出し、**double-checked パターン**を採用:
- キャッシュの読み書きのみロック下で行う
- ネットワーク呼び出し (ChainID) はロック外へ
- fast path は `RLock`、初回フェッチ確定時のみ `Lock`

### 2. `SignTx` が毎回 `ChainID` RPC を叩く問題
不変な `ChainID` を毎回取得していたため、共有ヘルパー `chainID()` 経由でキャッシュを使い回すように変更（最大1回のみ取得）。

## テスト

- 追加: `TestWallet_SignTx_CachesChainID` — 複数回 `SignTx` を呼んでも ChainID RPC が1回のみ
- 既存の `TestWallet_buildAuth` / `TestWallet_ResetPool` / race テストはグリーン
- `go test ./... -race`（e2e除く）パス

## 影響

高スループット時のレイテンシ削減と並行性の向上（送信の直列化を解消）。公開APIのシグネチャ変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
