### PR TITLE
feat: validate PrivateNetworkConfig.Url in NewAlchemyConfig

### DIFF
--- a/constant/errors.go
+++ b/constant/errors.go
@@ -49,6 +49,7 @@ var (
 	ErrUnexpectedResponseType           = errors.New("unexpected response type")
 	ErrBatchNotSent                     = errors.New("batch has not been sent yet")
 	ErrBatchAlreadySent                 = errors.New("batch has already been sent")
+	ErrInvalidPrivateNetworkUrl         = errors.New("invalid private network url")
 )
 
 var HttpClientErrorCodeList = []int{

--- a/gas/alchemy_config.go
+++ b/gas/alchemy_config.go
@@ -28,10 +28,9 @@ type AlchemyConfig struct {
 }
 
 func NewAlchemyConfig(setting AlchemySetting) (AlchemyConfig, error) {
-	if isPrivateNetwork(setting) {
-		if err := validate.Url(resolvePrivateNetUrl(setting)); err != nil {
-			return AlchemyConfig{}, err
-		}
+	resolvedUrl := settingToUrl(setting)
+	if err := validate.Url(resolvedUrl); err != nil {
+		return AlchemyConfig{}, err
 	}
 
 	decodedJwt, err := internal.DecodeHex(setting.PrivateNetworkConfig.JwtSecret)
@@ -46,7 +45,7 @@ func NewAlchemyConfig(setting AlchemySetting) (AlchemyConfig, error) {
 	config := AlchemyConfig{
 		apiKey:               setting.ApiKey,
 		network:              setting.Network,
-		url:                  settingToUrl(setting),
+		url:                  resolvedUrl,
 		maxRetries:           setting.MaxRetries,
 		requestTimeout:       setting.RequestTimeout,
 		isRequestBatch:       setting.IsRequestBatch,

--- a/gas/alchemy_config.go
+++ b/gas/alchemy_config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/poteto-go/go-alchemy-sdk/ether"
 	"github.com/poteto-go/go-alchemy-sdk/internal"
 	"github.com/poteto-go/go-alchemy-sdk/types"
+	"github.com/poteto-go/go-alchemy-sdk/validate"
 )
 
 type AlchemyConfig struct {
@@ -27,6 +28,10 @@ type AlchemyConfig struct {
 }
 
 func NewAlchemyConfig(setting AlchemySetting) (AlchemyConfig, error) {
+	if err := validate.Url(setting.PrivateNetworkConfig.Url); err != nil {
+		return AlchemyConfig{}, err
+	}
+
 	decodedJwt, err := internal.DecodeHex(setting.PrivateNetworkConfig.JwtSecret)
 	if err != nil {
 		return AlchemyConfig{}, err

--- a/gas/alchemy_config.go
+++ b/gas/alchemy_config.go
@@ -28,8 +28,10 @@ type AlchemyConfig struct {
 }
 
 func NewAlchemyConfig(setting AlchemySetting) (AlchemyConfig, error) {
-	if err := validate.Url(setting.PrivateNetworkConfig.Url); err != nil {
-		return AlchemyConfig{}, err
+	if isPrivateNetwork(setting) {
+		if err := validate.Url(resolvePrivateNetUrl(setting)); err != nil {
+			return AlchemyConfig{}, err
+		}
 	}
 
 	decodedJwt, err := internal.DecodeHex(setting.PrivateNetworkConfig.JwtSecret)

--- a/gas/alchemy_config_test.go
+++ b/gas/alchemy_config_test.go
@@ -124,6 +124,17 @@ func TestNewAlchemyConfig_PrivateNetworkUrlValidation(t *testing.T) {
 		})
 		assert.NoError(t, err)
 	})
+
+	t.Run("host+port path with empty host returns error", func(t *testing.T) {
+		_, err := NewAlchemyConfig(AlchemySetting{
+			PrivateNetworkConfig: PrivateNetworkConfig{
+				Host: "",
+				Port: 8545,
+			},
+			IsPrivateNetwork: func(AlchemySetting) bool { return true },
+		})
+		assert.ErrorIs(t, err, constant.ErrInvalidPrivateNetworkUrl)
+	})
 }
 
 func TestNewAlchemyConfig_MaxResponseBytes(t *testing.T) {

--- a/gas/alchemy_config_test.go
+++ b/gas/alchemy_config_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/poteto-go/go-alchemy-sdk/constant"
 	"github.com/poteto-go/go-alchemy-sdk/ether"
 	"github.com/poteto-go/go-alchemy-sdk/types"
 	"github.com/stretchr/testify/assert"
@@ -67,6 +68,61 @@ func TestNewAlchemyConfig(t *testing.T) {
 		assert.Equal(t, config.apiKey, "api-key")
 		assert.Equal(t, string(config.network), "matic-mainnet")
 		assert.Equal(t, config.url, "https://matic-mainnet.g.alchemy.com/v2/api-key")
+	})
+}
+
+func TestNewAlchemyConfig_PrivateNetworkUrlValidation(t *testing.T) {
+	t.Run("valid http url is accepted", func(t *testing.T) {
+		_, err := NewAlchemyConfig(AlchemySetting{
+			PrivateNetworkConfig: PrivateNetworkConfig{
+				Url: "http://localhost:8545",
+			},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid https url is accepted", func(t *testing.T) {
+		_, err := NewAlchemyConfig(AlchemySetting{
+			PrivateNetworkConfig: PrivateNetworkConfig{
+				Url: "https://my-rpc.example.com",
+			},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid scheme returns error", func(t *testing.T) {
+		_, err := NewAlchemyConfig(AlchemySetting{
+			PrivateNetworkConfig: PrivateNetworkConfig{
+				Url: "ftp://bad-scheme.com",
+			},
+		})
+		assert.ErrorIs(t, err, constant.ErrInvalidPrivateNetworkUrl)
+	})
+
+	t.Run("missing scheme returns error", func(t *testing.T) {
+		_, err := NewAlchemyConfig(AlchemySetting{
+			PrivateNetworkConfig: PrivateNetworkConfig{
+				Url: "localhost:8545",
+			},
+		})
+		assert.ErrorIs(t, err, constant.ErrInvalidPrivateNetworkUrl)
+	})
+
+	t.Run("empty host returns error", func(t *testing.T) {
+		_, err := NewAlchemyConfig(AlchemySetting{
+			PrivateNetworkConfig: PrivateNetworkConfig{
+				Url: "http://",
+			},
+		})
+		assert.ErrorIs(t, err, constant.ErrInvalidPrivateNetworkUrl)
+	})
+
+	t.Run("empty url is not validated (no private network)", func(t *testing.T) {
+		_, err := NewAlchemyConfig(AlchemySetting{
+			ApiKey:  "api-key",
+			Network: types.MaticMainnet,
+		})
+		assert.NoError(t, err)
 	})
 }
 

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -61,7 +61,7 @@ func Url(rawUrl string) error {
 		return nil
 	}
 	u, _ := url.Parse(rawUrl)
-	if u == nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+	if u == nil || (u.Scheme != "http" && u.Scheme != "https") || u.Hostname() == "" {
 		return constant.ErrInvalidPrivateNetworkUrl
 	}
 	return nil

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"math/big"
+	"net/url"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/poteto-go/go-alchemy-sdk/constant"
@@ -51,6 +52,17 @@ func BlockTag(blockTag string) error {
 	}
 	if _, ok := new(big.Int).SetString(blockTag[2:], 16); !ok {
 		return constant.ErrInvalidBlockTag
+	}
+	return nil
+}
+
+func Url(rawUrl string) error {
+	if rawUrl == "" {
+		return nil
+	}
+	u, _ := url.Parse(rawUrl)
+	if u == nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return constant.ErrInvalidPrivateNetworkUrl
 	}
 	return nil
 }

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -118,6 +118,7 @@ func TestUrl(t *testing.T) {
 		{"invalid scheme", "ftp://bad-scheme.com", constant.ErrInvalidPrivateNetworkUrl},
 		{"missing scheme", "localhost:8545", constant.ErrInvalidPrivateNetworkUrl},
 		{"empty host", "http://", constant.ErrInvalidPrivateNetworkUrl},
+		{"empty hostname with port", "http://:8545", constant.ErrInvalidPrivateNetworkUrl},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -106,6 +106,26 @@ func TestBlockTag(t *testing.T) {
 	}
 }
 
+func TestUrl(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawUrl  string
+		wantErr error
+	}{
+		{"empty is allowed", "", nil},
+		{"valid http", "http://localhost:8545", nil},
+		{"valid https", "https://my-rpc.example.com", nil},
+		{"invalid scheme", "ftp://bad-scheme.com", constant.ErrInvalidPrivateNetworkUrl},
+		{"missing scheme", "localhost:8545", constant.ErrInvalidPrivateNetworkUrl},
+		{"empty host", "http://", constant.ErrInvalidPrivateNetworkUrl},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ErrorIs(t, validate.Url(tt.rawUrl), tt.wantErr)
+		})
+	}
+}
+
 func TestABIString(t *testing.T) {
 	t.Run("normal case: valid header and length", func(t *testing.T) {
 		// header declares length 3 with a full data word following.


### PR DESCRIPTION
Closes #417

## Summary
- Add `validate.Url` to the `validate` package (consistent with `validate.Address`, `validate.BlockTag`, etc.)
- Call `validate.Url` from `NewAlchemyConfig` to reject non-HTTP(S) or hostless private network URLs at construction time
- Shorten `ErrInvalidPrivateNetworkUrl` message to match the codebase's sentinel style (`"invalid private network url"`)

## Test plan
- [ ] `go test ./gas/...` — `TestNewAlchemyConfig_PrivateNetworkUrlValidation` covers valid http/https, invalid scheme, missing scheme, empty host, and empty URL
- [ ] `go test ./validate/...` — `TestUrl` covers the same cases at the `validate.Url` unit level

🤖 Generated with [Claude Code](https://claude.com/claude-code)