### PR TITLE
feat: add Debug namespace with Snapshot & RevertTo. refs: #419

### DIFF
--- a/constant/errors.go
+++ b/constant/errors.go
@@ -50,6 +50,7 @@ var (
 	ErrBatchNotSent                     = errors.New("batch has not been sent yet")
 	ErrBatchAlreadySent                 = errors.New("batch has already been sent")
 	ErrInvalidPrivateNetworkUrl         = errors.New("invalid private network url")
+	ErrNilSnapshotId                    = errors.New("snapshot id must not be nil")
 )
 
 var HttpClientErrorCodeList = []int{

--- a/constant/ether_methods.go
+++ b/constant/ether_methods.go
@@ -21,6 +21,11 @@ var (
 )
 
 var (
+	Evm_Snapshot = "evm_snapshot"
+	Evm_Revert   = "evm_revert"
+)
+
+var (
 	Alchemy_GetTokenBalances    = "alchemy_getTokenBalances"
 	Alchemy_GetTokenMetadata    = "alchemy_getTokenMetadata"
 	Alchemy_TransactionReceipts = "alchemy_getTransactionReceipts"

--- a/docs/docs/debug-namespace/RevertTo.md
+++ b/docs/docs/debug-namespace/RevertTo.md
@@ -1,0 +1,26 @@
+![](https://img.shields.io/badge/dev-chain_only-orange)
+
+RevertTo reverts the blockchain state to the provided snapshot id with `evm_revert`.
+It returns true if the state was reverted.
+
+A snapshot can only be reverted once. After a successful revert, take a new
+snapshot if you want to revert to the same state again.
+
+Only supported on development chains (hardhat, anvil, ganache, ...).
+
+```go
+func RevertTo(snapshotId *big.Int) (reverted bool, err error)
+```
+
+```go
+func main() {
+	...
+	alchemy := gas.NewAlchemy(setting)
+
+	snapshotId, err := alchemy.Debug.Snapshot()
+
+	// mutate blockchain state (send transactions, ...)
+
+	reverted, err := alchemy.Debug.RevertTo(snapshotId)
+}
+```

--- a/docs/docs/debug-namespace/Snapshot.md
+++ b/docs/docs/debug-namespace/Snapshot.md
@@ -1,0 +1,18 @@
+![](https://img.shields.io/badge/dev-chain_only-orange)
+
+Snapshot takes a snapshot of the current blockchain state with `evm_snapshot`
+and returns the snapshot id.
+
+Only supported on development chains (hardhat, anvil, ganache, ...).
+
+```go
+func Snapshot() (snapshotId *big.Int, err error)
+```
+
+```go
+func main() {
+	...
+	alchemy := gas.NewAlchemy(setting)
+	snapshotId, err := alchemy.Debug.Snapshot()
+}
+```

--- a/docs/docs/debug-namespace/_category_.json
+++ b/docs/docs/debug-namespace/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Debug Namespace",
+  "position": 16
+}

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -900,3 +900,47 @@ func TestScenario_SendTransaction(t *testing.T) {
 		assert.Equal(t, txHash, tx.Hash())
 	})
 }
+
+func TestScenario_DebugSnapshotRevertTo(t *testing.T) {
+	// 1. snapshot
+	snapshotId, err := alchemy.Debug.Snapshot()
+	if err != nil {
+		// evm_snapshot is only supported on development chains
+		// (anvil, hardhat, ganache, ...), not on the kurtosis geth network.
+		t.Skipf("node does not support evm_snapshot: %v", err)
+	}
+
+	balanceBefore, err := alchemy.Core.GetBalance(otherAddress, "latest")
+	assert.Nil(t, err)
+
+	// 2. transfer native
+	w, err := wallet.New(initPrivateKey)
+	assert.Nil(t, err)
+	w.Connect(alchemy.GetProvider())
+
+	txHash, err := w.SendTransaction(types.TransactionRequest{
+		From:     initAddress,
+		To:       otherAddress,
+		Value:    "0x123",
+		GasLimit: 300000,
+	})
+	assert.Nil(t, err)
+
+	_, err = alchemy.Transact.WaitMined(context.Background(), txHash.Hex())
+	assert.Nil(t, err)
+
+	// 3. balance check
+	balanceAfter, err := alchemy.Core.GetBalance(otherAddress, "latest")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, balanceAfter.Cmp(balanceBefore))
+
+	// 4. revert to
+	reverted, err := alchemy.Debug.RevertTo(snapshotId)
+	assert.Nil(t, err)
+	assert.True(t, reverted)
+
+	// 5. balance check
+	balanceReverted, err := alchemy.Core.GetBalance(otherAddress, "latest")
+	assert.Nil(t, err)
+	assert.Equal(t, 0, balanceReverted.Cmp(balanceBefore))
+}

--- a/ether/ether_debug.go
+++ b/ether/ether_debug.go
@@ -1,0 +1,49 @@
+package ether
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/poteto-go/go-alchemy-sdk/constant"
+	"github.com/poteto-go/go-alchemy-sdk/types"
+	"github.com/poteto-go/go-alchemy-sdk/utils"
+)
+
+func (ether *Ether) Snapshot() (*big.Int, error) {
+	result, err := ether.provider.Send(constant.Evm_Snapshot, types.RequestArgs{})
+	if err != nil {
+		return nil, err
+	}
+
+	resultStr, ok := result.(string)
+	if !ok {
+		return nil, constant.ErrUnexpectedResponseType
+	}
+
+	snapshotId, err := utils.FromBigHex(resultStr)
+	if err != nil {
+		return nil, err
+	}
+
+	return snapshotId, nil
+}
+
+func (ether *Ether) RevertTo(snapshotId *big.Int) (bool, error) {
+	if snapshotId == nil {
+		return false, constant.ErrNilSnapshotId
+	}
+
+	result, err := ether.provider.Send(constant.Evm_Revert, types.RequestArgs{
+		hexutil.EncodeBig(snapshotId),
+	})
+	if err != nil {
+		return false, err
+	}
+
+	reverted, ok := result.(bool)
+	if !ok {
+		return false, constant.ErrUnexpectedResponseType
+	}
+
+	return reverted, nil
+}

--- a/ether/ether_debug_test.go
+++ b/ether/ether_debug_test.go
@@ -1,0 +1,167 @@
+package ether_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEther_Snapshot(t *testing.T) {
+	t.Run("normal case:", func(t *testing.T) {
+		t.Run("return snapshot id", func(t *testing.T) {
+			// Arrange
+			e := newEtherApiForTest()
+			alchemyMock := newAlchemyMockOnEtherTest(t)
+			defer alchemyMock.DeactivateAndReset()
+
+			// Mock
+			alchemyMock.RegisterResponderOnce(
+				"evm_snapshot",
+				`{"jsonrpc":"2.0","id":1,"result":"0x1"}`,
+			)
+
+			// Act
+			snapshotId, err := e.Snapshot()
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, big.NewInt(1), snapshotId)
+		})
+	})
+
+	t.Run("error case:", func(t *testing.T) {
+		t.Run("if rpc call fails, return error", func(t *testing.T) {
+			// Arrange
+			e := newEtherApiForTest()
+			alchemyMock := newAlchemyMockOnEtherTest(t)
+			defer alchemyMock.DeactivateAndReset()
+
+			// Mock
+			alchemyMock.RegisterResponderOnce(
+				"evm_snapshot",
+				`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}`,
+			)
+
+			// Act
+			_, err := e.Snapshot()
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if result is not hex string, return error", func(t *testing.T) {
+			// Arrange
+			e := newEtherApiForTest()
+			alchemyMock := newAlchemyMockOnEtherTest(t)
+			defer alchemyMock.DeactivateAndReset()
+
+			// Mock
+			alchemyMock.RegisterResponderOnce(
+				"evm_snapshot",
+				`{"jsonrpc":"2.0","id":1,"result":12}`,
+			)
+
+			// Act
+			_, err := e.Snapshot()
+
+			// Assert
+			assert.Error(t, err)
+		})
+	})
+}
+
+func TestEther_RevertTo(t *testing.T) {
+	t.Run("normal case:", func(t *testing.T) {
+		t.Run("return true if reverted", func(t *testing.T) {
+			// Arrange
+			e := newEtherApiForTest()
+			alchemyMock := newAlchemyMockOnEtherTest(t)
+			defer alchemyMock.DeactivateAndReset()
+
+			// Mock
+			alchemyMock.RegisterResponderOnce(
+				"evm_revert",
+				`{"jsonrpc":"2.0","id":1,"result":true}`,
+			)
+
+			// Act
+			reverted, err := e.RevertTo(big.NewInt(1))
+
+			// Assert
+			assert.NoError(t, err)
+			assert.True(t, reverted)
+		})
+
+		t.Run("return false if snapshot does not exist", func(t *testing.T) {
+			// Arrange
+			e := newEtherApiForTest()
+			alchemyMock := newAlchemyMockOnEtherTest(t)
+			defer alchemyMock.DeactivateAndReset()
+
+			// Mock
+			alchemyMock.RegisterResponderOnce(
+				"evm_revert",
+				`{"jsonrpc":"2.0","id":1,"result":false}`,
+			)
+
+			// Act
+			reverted, err := e.RevertTo(big.NewInt(99))
+
+			// Assert
+			assert.NoError(t, err)
+			assert.False(t, reverted)
+		})
+	})
+
+	t.Run("error case:", func(t *testing.T) {
+		t.Run("if snapshot id is nil, return error", func(t *testing.T) {
+			// Arrange
+			e := newEtherApiForTest()
+
+			// Act
+			_, err := e.RevertTo(nil)
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if rpc call fails, return error", func(t *testing.T) {
+			// Arrange
+			e := newEtherApiForTest()
+			alchemyMock := newAlchemyMockOnEtherTest(t)
+			defer alchemyMock.DeactivateAndReset()
+
+			// Mock
+			alchemyMock.RegisterResponderOnce(
+				"evm_revert",
+				`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}`,
+			)
+
+			// Act
+			_, err := e.RevertTo(big.NewInt(1))
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if result is not bool, return error", func(t *testing.T) {
+			// Arrange
+			e := newEtherApiForTest()
+			alchemyMock := newAlchemyMockOnEtherTest(t)
+			defer alchemyMock.DeactivateAndReset()
+
+			// Mock
+			alchemyMock.RegisterResponderOnce(
+				"evm_revert",
+				`{"jsonrpc":"2.0","id":1,"result":"yes"}`,
+			)
+
+			// Act
+			_, err := e.RevertTo(big.NewInt(1))
+
+			// Assert
+			assert.Error(t, err)
+		})
+	})
+}

--- a/gas/alchemy.go
+++ b/gas/alchemy.go
@@ -13,6 +13,7 @@ type Alchemy struct {
 	Nft        namespace.INft
 	ERC20      namespace.IERC20
 	StableCoin namespace.IStableCoin
+	Debug      namespace.IDebug
 	provider   types.IAlchemyProvider
 }
 
@@ -33,6 +34,7 @@ func NewAlchemy(setting AlchemySetting) (Alchemy, error) {
 	nftNamespace := namespace.NewNftNamespace(ether)
 	erc20Namespace := namespace.NewERC20Namespace(ether)
 	stableCoinNamespace := namespace.NewStableCoinNamespace(ether)
+	debugNamespace := namespace.NewDebugNamespace(ether)
 
 	return Alchemy{
 		config:     alchemyConfig,
@@ -41,6 +43,7 @@ func NewAlchemy(setting AlchemySetting) (Alchemy, error) {
 		Nft:        nftNamespace,
 		ERC20:      erc20Namespace,
 		StableCoin: stableCoinNamespace,
+		Debug:      debugNamespace,
 		provider:   alchemyProvider,
 	}, nil
 }

--- a/gas/alchemy_test.go
+++ b/gas/alchemy_test.go
@@ -25,6 +25,7 @@ func TestNewAlchemy(t *testing.T) {
 	assert.NotNil(t, alchemy.Core)
 	assert.NotNil(t, alchemy.Transact)
 	assert.NotNil(t, alchemy.Nft)
+	assert.NotNil(t, alchemy.Debug)
 }
 
 func TestAlchemy_GetProvider(t *testing.T) {

--- a/namespace/debug_namespace.go
+++ b/namespace/debug_namespace.go
@@ -1,0 +1,53 @@
+package namespace
+
+import (
+	"math/big"
+
+	"github.com/poteto-go/go-alchemy-sdk/types"
+)
+
+type IDebug interface {
+	/*
+		Snapshot takes a snapshot of the current blockchain state with evm_snapshot
+		and returns the snapshot id.
+
+		Only supported on development chains (hardhat, anvil, ganache, ...).
+	*/
+	Snapshot() (*big.Int, error)
+
+	/*
+		RevertTo reverts the blockchain state to the provided snapshot id with evm_revert.
+		It returns true if the state was reverted.
+
+		Only supported on development chains (hardhat, anvil, ganache, ...).
+	*/
+	RevertTo(snapshotId *big.Int) (bool, error)
+}
+
+type Debug struct {
+	ether types.EtherApi
+}
+
+func NewDebugNamespace(ether types.EtherApi) IDebug {
+	return &Debug{
+		ether: ether,
+	}
+}
+
+func (d *Debug) Snapshot() (*big.Int, error) {
+	snapshotId, err := d.ether.Snapshot()
+	if err != nil {
+		return nil, err
+	}
+
+	return snapshotId, nil
+}
+
+func (d *Debug) RevertTo(snapshotId *big.Int) (bool, error) {
+	reverted, err := d.ether.RevertTo(snapshotId)
+	if err != nil {
+		return false, err
+	}
+
+	return reverted, nil
+}

--- a/namespace/debug_namespace_test.go
+++ b/namespace/debug_namespace_test.go
@@ -1,0 +1,131 @@
+package namespace_test
+
+import (
+	"errors"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/agiledragon/gomonkey"
+	"github.com/poteto-go/go-alchemy-sdk/ether"
+	"github.com/poteto-go/go-alchemy-sdk/namespace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDebugNamespace(t *testing.T) {
+	// Arrange
+	ether := newEtherApi()
+
+	// Act
+	debug := namespace.NewDebugNamespace(ether)
+
+	// Assert
+	assert.NotNil(t, debug)
+}
+
+func TestDebug_Snapshot(t *testing.T) {
+	// Arrange
+	api := newEtherApi()
+	debug := namespace.NewDebugNamespace(api).(*namespace.Debug)
+
+	t.Run("call ether.Snapshot & return snapshot id", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange
+		expectedId := big.NewInt(1)
+
+		// Mock
+		patches.ApplyMethod(
+			reflect.TypeOf(api),
+			"Snapshot",
+			func(_ *ether.Ether) (*big.Int, error) {
+				return expectedId, nil
+			},
+		)
+
+		// Act
+		snapshotId, err := debug.Snapshot()
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, expectedId, snapshotId)
+	})
+
+	t.Run("if error occur, return error", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange
+		expectedErr := errors.New("error")
+
+		// Mock
+		patches.ApplyMethod(
+			reflect.TypeOf(api),
+			"Snapshot",
+			func(_ *ether.Ether) (*big.Int, error) {
+				return nil, expectedErr
+			},
+		)
+
+		// Act
+		_, err := debug.Snapshot()
+
+		// Assert
+		assert.ErrorIs(t, err, expectedErr)
+	})
+}
+
+func TestDebug_RevertTo(t *testing.T) {
+	// Arrange
+	api := newEtherApi()
+	debug := namespace.NewDebugNamespace(api).(*namespace.Debug)
+
+	t.Run("call ether.RevertTo & return result", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange
+		expectedId := big.NewInt(1)
+
+		// Mock & Assert
+		patches.ApplyMethod(
+			reflect.TypeOf(api),
+			"RevertTo",
+			func(_ *ether.Ether, snapshotId *big.Int) (bool, error) {
+				assert.Equal(t, expectedId, snapshotId)
+				return true, nil
+			},
+		)
+
+		// Act
+		reverted, err := debug.RevertTo(expectedId)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.True(t, reverted)
+	})
+
+	t.Run("if error occur, return error", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange
+		expectedErr := errors.New("error")
+
+		// Mock
+		patches.ApplyMethod(
+			reflect.TypeOf(api),
+			"RevertTo",
+			func(_ *ether.Ether, snapshotId *big.Int) (bool, error) {
+				return false, expectedErr
+			},
+		)
+
+		// Act
+		_, err := debug.RevertTo(big.NewInt(1))
+
+		// Assert
+		assert.ErrorIs(t, err, expectedErr)
+	})
+}

--- a/types/ether_api.go
+++ b/types/ether_api.go
@@ -227,6 +227,22 @@ type EtherApi interface {
 	WaitDeployed(ctx context.Context, hash common.Hash) (common.Address, error)
 
 	/*
+		Snapshot takes a snapshot of the current blockchain state with evm_snapshot
+		and returns the snapshot id.
+
+		Only supported on development chains (hardhat, anvil, ganache, ...).
+	*/
+	Snapshot() (*big.Int, error)
+
+	/*
+		RevertTo reverts the blockchain state to the provided snapshot id with evm_revert.
+		It returns true if the state was reverted.
+
+		Only supported on development chains (hardhat, anvil, ganache, ...).
+	*/
+	RevertTo(snapshotId *big.Int) (bool, error)
+
+	/*
 		ContractCall calls a contract.
 
 		internal call geth


### PR DESCRIPTION
## Summary

Closes #419

Adds a `Debug` namespace to `gas.Alchemy` exposing dev-chain state snapshot/rollback:

```go
snapshotId, err := alchemy.Debug.Snapshot()      // evm_snapshot
reverted, err := alchemy.Debug.RevertTo(snapshotId) // evm_revert
```

- `ether.Snapshot()` / `ether.RevertTo(*big.Int)` via `provider.Send`, decoding the hex snapshot id with `utils.FromBigHex` (same pattern as `GetBalance`) and the revert result as `bool`
- `namespace.IDebug` + `Debug` thin wrapper, wired into `gas.Alchemy` like the other namespaces
- new constants `Evm_Snapshot` / `Evm_Revert` and `ErrNilSnapshotId`
- docs: `docs/docs/debug-namespace/{Snapshot,RevertTo}.md`
- e2e: `TestScenario_DebugSnapshotRevertTo` follows the issue scenario (snapshot → native transfer → balance check → revert → balance check)

## Note on e2e

`evm_snapshot`/`evm_revert` are only available on development chains (anvil, hardhat, ganache, ...). The kurtosis geth network returns `-32601 method not found` (verified locally), so the e2e scenario skips with `t.Skipf` when the node doesn't support the method and runs fully on dev chains.

## Testing

- TDD: unit tests for ether layer (alchemymock) and namespace layer (gomonkey); `just ut` green
- `just lint` 0 issues
- Full e2e suite against local kurtosis (port 32769) passes (new scenario skips as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)