### PR TITLE
:boom: feat: remove ContractInstance param from ContractTransact & ContractTransactNoWait. refs: #430

### DIFF
--- a/constant/errors.go
+++ b/constant/errors.go
@@ -38,7 +38,6 @@ var (
 	ErrInvalidArgs                      = errors.New("invalid args")
 	ErrOverFlow                         = errors.New("overflow")
 	ErrWalletIsNotConnected             = errors.New("wallet is not connected")
-	ErrContractInstanceIsNil            = errors.New("contract instance is nil")
 	ErrNilAmount                        = errors.New("amount must not be nil")
 	ErrNegativeAmount                   = errors.New("amount must not be negative")
 	ErrAmountExceedsUint256             = errors.New("amount exceeds uint256 max")

--- a/docs/docs/wallet/ContractTransact.md
+++ b/docs/docs/wallet/ContractTransact.md
@@ -19,7 +19,6 @@ cf.) [`wallet.ContractTransactNoWait`](./ContractTransactNoWait.md)
 ```go
 func ContractTransact(
 	ctx context.Context,
-	contract types.ContractInstance,
 	contractAddress string,
 	data []byte,
 ) (txReceipt *gethTypes.Receipt, err error)
@@ -36,15 +35,13 @@ func main() {
 	w, _ := wallet.New("<privateKey>")
 	w.Connect(alchemy.GetProvider())
 
-	// Create contract instance
-	contract := abi.NewYourContract()
 	contractAddress := "0x1234567890123456789012345678901234567890"
 
 	// Prepare transaction data (e.g., encoded function call)
 	data := abi.PackXXX(<data>)
 
 	// Execute transaction
-	receipt, err := w.ContractTransact(context.Background(), contract, contractAddress, data)
+	receipt, err := w.ContractTransact(context.Background(), contractAddress, data)
 	if err != nil {
 		panic(err)
 	}

--- a/docs/docs/wallet/ContractTransactNoWait.md
+++ b/docs/docs/wallet/ContractTransactNoWait.md
@@ -19,7 +19,6 @@ cf.) [`wallet.ContractTransact`](./ContractTransact.md)
 
 ```go
 func ContractTransactNoWait(
-	contract types.ContractInstance,
 	contractAddress string,
 	data []byte,
 ) (tx *gethTypes.Transaction, err error)
@@ -36,15 +35,13 @@ func main() {
 	w, _ := wallet.New("<privateKey>")
 	w.Connect(alchemy.GetProvider())
 
-	// Create contract instance
-	contract := abi.NewYourContract()
 	contractAddress := "0x1234567890123456789012345678901234567890"
 
 	// Prepare transaction data (e.g., encoded function call)
 	data := abi.PackXXX(<data>)
 
 	// Execute transaction
-	tx, err := w.ContractTransactNoWait(contract, contractAddress, data)
+	tx, err := w.ContractTransactNoWait(contractAddress, data)
 	if err != nil {
 		panic(err)
 	}

--- a/docs/docs/wallet/ResetPool.md
+++ b/docs/docs/wallet/ResetPool.md
@@ -32,18 +32,17 @@ func main() {
 	w.Connect(alchemy.GetProvider())
 
 	// Use wallet for transactions
-	contract := artifacts.NewYourContract()
 	contractAddress := "0x1234567890123456789012345678901234567890"
 	data := []byte("encoded transaction data")
-	
-	receipt, _ := w.ContractTransact(contract, contractAddress, data)
+
+	receipt, _ := w.ContractTransact(context.Background(), contractAddress, data)
 	fmt.Printf("Transaction 1: %s\n", receipt.TxHash)
 
 	// Reset cache if needed (e.g., after network switch)
 	w.ResetPool()
 
 	// Next transaction will fetch fresh ChainID and create new auth
-	receipt2, _ := w.ContractTransact(contract, contractAddress, data)
+	receipt2, _ := w.ContractTransact(context.Background(), contractAddress, data)
 	fmt.Printf("Transaction 2: %s\n", receipt2.TxHash)
 }
 ```

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/poteto-go/go-alchemy-sdk/_fixture/artifacts"
 	"github.com/poteto-go/go-alchemy-sdk/batch"
@@ -195,6 +196,40 @@ func TestSenario_DeployContract(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Greater(t, blockNumber, uint64(0))
 		})
+	})
+}
+
+func TestScenario_ContractTransact(t *testing.T) {
+	t.Run("1. deploy contract 2. transact store 3. verify stored value", func(t *testing.T) {
+		w, err := wallet.New(initPrivateKey)
+
+		assert.Nil(t, err)
+
+		w.Connect(alchemy.GetProvider())
+
+		contract := artifacts.NewPotetoStorage()
+		contractAddress, err := w.DeployContract(context.Background(), &artifacts.PotetoStorageMetaData)
+
+		assert.Nil(t, err)
+
+		// transact store(42) without a contract instance
+		data := contract.PackStore(big.NewInt(42))
+		receipt, err := w.ContractTransact(context.Background(), contractAddress.Hex(), data)
+
+		assert.Nil(t, err)
+		assert.Equal(t, uint64(1), receipt.Status)
+
+		// verify stored value via retrieve
+		res, err := w.ContractCall(
+			contract,
+			contractAddress.Hex(),
+			&bind.CallOpts{},
+			contract.PackRetrieve(),
+			func(b []byte) (any, error) { return contract.UnpackRetrieve(b) },
+		)
+
+		assert.Nil(t, err)
+		assert.Equal(t, 0, res.(*big.Int).Cmp(big.NewInt(42)))
 	})
 }
 

--- a/ether/ether.go
+++ b/ether/ether.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -777,19 +778,16 @@ func (ether *Ether) DeployContract(
 }
 
 // TODO: backoff
-func (ether *Ether) ContractTransact(auth *bind.TransactOpts, contract types.ContractInstance, contractAddress string, data []byte) (*gethTypes.Transaction, error) {
-	if contract == nil {
-		return nil, constant.ErrContractInstanceIsNil
-	}
-
+func (ether *Ether) ContractTransact(auth *bind.TransactOpts, contractAddress string, data []byte) (*gethTypes.Transaction, error) {
 	err := ether.SetEthClient()
 	if err != nil {
 		return nil, err
 	}
 	defer ether.Close()
 
+	// data is already ABI-encoded, so bind only needs the address and backend.
 	c := ether.Client()
-	instance := contract.Instance(c, common.HexToAddress(contractAddress))
+	instance := bind.NewBoundContract(common.HexToAddress(contractAddress), abi.ABI{}, c, c, c)
 
 	tx, err := bind.Transact(
 		instance, auth, data,

--- a/ether/ether_wallet_test.go
+++ b/ether/ether_wallet_test.go
@@ -171,7 +171,6 @@ func TestEther_ContractTransact(t *testing.T) {
 
 			// Arrange
 			ether := newEtherApiForTest()
-			contract := artifacts.NewPotetoStorage()
 
 			signedTx := gethTypes.NewTx(txData)
 
@@ -184,7 +183,7 @@ func TestEther_ContractTransact(t *testing.T) {
 			)
 
 			// Act
-			res, err := ether.ContractTransact(nil, contract, "", []byte(""))
+			res, err := ether.ContractTransact(nil, "", []byte(""))
 
 			// Assert
 			assert.NoError(t, err)
@@ -193,27 +192,12 @@ func TestEther_ContractTransact(t *testing.T) {
 	})
 
 	t.Run("error case", func(t *testing.T) {
-		t.Run("if contract is nil, return error", func(t *testing.T) {
-			patches := gomonkey.NewPatches()
-			defer patches.Reset()
-
-			// Arrange
-			ether := newEtherApiForTest()
-
-			// Act
-			_, err := ether.ContractTransact(nil, nil, "", []byte(""))
-
-			// Assert
-			assert.Error(t, err)
-		})
-
 		t.Run("if failed to create connection, retunr error", func(t *testing.T) {
 			patches := gomonkey.NewPatches()
 			defer patches.Reset()
 
 			// Arrange
 			ether := newEtherApiForTest()
-			contract := artifacts.NewPotetoStorage()
 
 			// Mock
 			patches.ApplyMethod(
@@ -225,7 +209,7 @@ func TestEther_ContractTransact(t *testing.T) {
 			)
 
 			// Act
-			_, err := ether.ContractTransact(nil, contract, "", []byte(""))
+			_, err := ether.ContractTransact(nil, "", []byte(""))
 
 			// Assert
 			assert.Error(t, err)
@@ -237,7 +221,6 @@ func TestEther_ContractTransact(t *testing.T) {
 
 			// Arrange
 			ether := newEtherApiForTest()
-			contract := artifacts.NewPotetoStorage()
 
 			// Mock
 			patches.ApplyFunc(
@@ -248,7 +231,7 @@ func TestEther_ContractTransact(t *testing.T) {
 			)
 
 			// Act
-			_, err := ether.ContractTransact(nil, contract, "", []byte(""))
+			_, err := ether.ContractTransact(nil, "", []byte(""))
 
 			// Assert
 			assert.Error(t, err)

--- a/types/ether_api.go
+++ b/types/ether_api.go
@@ -207,7 +207,6 @@ type EtherApi interface {
 	*/
 	ContractTransact(
 		auth *bind.TransactOpts,
-		contract ContractInstance,
 		contractAddress string,
 		data []byte,
 	) (txReceipt *gethTypes.Transaction, err error)

--- a/types/wallet.go
+++ b/types/wallet.go
@@ -69,7 +69,6 @@ type Wallet interface {
 	*/
 	ContractTransact(
 		ctx context.Context,
-		contract ContractInstance,
 		contractAddress string,
 		data []byte,
 	) (*gethTypes.Receipt, error)
@@ -79,11 +78,10 @@ type Wallet interface {
 
 		You can wait deployment using deployRes.
 
-			tx, err := wallet.ContractTransactNoWait(contract, addr, data)
+			tx, err := wallet.ContractTransactNoWait(addr, data)
 			txReceipt, err := alchemy.Transact.WaitDeployed(tx.Hash().Hex())
 	*/
 	ContractTransactNoWait(
-		contract ContractInstance,
 		contractAddress string,
 		data []byte,
 	) (*gethTypes.Transaction, error)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -233,7 +233,6 @@ func (w *wallet) DeployContractNoWait(metaData *bind.MetaData) (*bind.Deployment
 
 func (w *wallet) ContractTransact(
 	ctx context.Context,
-	contract types.ContractInstance,
 	contractAddress string,
 	data []byte,
 ) (*gethTypes.Receipt, error) {
@@ -243,7 +242,6 @@ func (w *wallet) ContractTransact(
 	}
 
 	tx, err := w.ContractTransactNoWait(
-		contract,
 		contractAddress,
 		data,
 	)
@@ -255,7 +253,6 @@ func (w *wallet) ContractTransact(
 }
 
 func (w *wallet) ContractTransactNoWait(
-	contract types.ContractInstance,
 	contractAddress string,
 	data []byte,
 ) (*gethTypes.Transaction, error) {
@@ -269,7 +266,7 @@ func (w *wallet) ContractTransactNoWait(
 		return nil, err
 	}
 
-	tx, err := provider.Eth().ContractTransact(auth, contract, contractAddress, data)
+	tx, err := provider.Eth().ContractTransact(auth, contractAddress, data)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/wallet_race_test.go
+++ b/wallet/wallet_race_test.go
@@ -104,7 +104,6 @@ func TestWallet_NoRaceConnectVsReaders(t *testing.T) {
 		func(
 			_ *ether.Ether,
 			_ *bind.TransactOpts,
-			_ types.ContractInstance,
 			_ string,
 			_ []byte,
 		) (*gethTypes.Transaction, error) {
@@ -165,7 +164,7 @@ func TestWallet_NoRaceConnectVsReaders(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < iterations; i++ {
-			_, _ = w.ContractTransactNoWait(contract, contractAddress, callData)
+			_, _ = w.ContractTransactNoWait(contractAddress, callData)
 		}
 	}()
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1244,7 +1244,6 @@ func TestWallet_DeployContractNoWait(t *testing.T) {
 }
 
 func TestWallet_ContractTransact(t *testing.T) {
-	contract := artifacts.NewPotetoStorage()
 	contractAddress := "0x1234567890123456789012345678901234567890"
 	data := []byte("test data")
 
@@ -1280,7 +1279,6 @@ func TestWallet_ContractTransact(t *testing.T) {
 			"ContractTransactNoWait",
 			func(
 				_ *wallet,
-				_ types.ContractInstance,
 				_ string,
 				_ []byte,
 			) (*gethTypes.Transaction, error) {
@@ -1296,7 +1294,7 @@ func TestWallet_ContractTransact(t *testing.T) {
 		)
 
 		// Act
-		txReceipt, err := w.ContractTransact(context.Background(), contract, contractAddress, data)
+		txReceipt, err := w.ContractTransact(context.Background(), contractAddress, data)
 
 		//Assert
 		assert.Nil(t, err)
@@ -1307,7 +1305,7 @@ func TestWallet_ContractTransact(t *testing.T) {
 		w, _ := New(testPrivHex)
 
 		// Act
-		_, err := w.ContractTransact(context.Background(), contract, contractAddress, data)
+		_, err := w.ContractTransact(context.Background(), contractAddress, data)
 
 		// Assert
 		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
@@ -1333,7 +1331,6 @@ func TestWallet_ContractTransact(t *testing.T) {
 			"ContractTransactNoWait",
 			func(
 				_ *wallet,
-				_ types.ContractInstance,
 				_ string,
 				_ []byte,
 			) (*gethTypes.Transaction, error) {
@@ -1342,7 +1339,7 @@ func TestWallet_ContractTransact(t *testing.T) {
 		)
 
 		// Act
-		_, err := w.ContractTransact(context.Background(), contract, contractAddress, data)
+		_, err := w.ContractTransact(context.Background(), contractAddress, data)
 
 		//Assert
 		assert.Error(t, err)
@@ -1377,7 +1374,6 @@ func TestWallet_ContractTransact(t *testing.T) {
 			"ContractTransactNoWait",
 			func(
 				_ *wallet,
-				_ types.ContractInstance,
 				_ string,
 				_ []byte,
 			) (*gethTypes.Transaction, error) {
@@ -1393,7 +1389,7 @@ func TestWallet_ContractTransact(t *testing.T) {
 		)
 
 		// Act
-		_, err := w.ContractTransact(context.Background(), contract, contractAddress, data)
+		_, err := w.ContractTransact(context.Background(), contractAddress, data)
 
 		// Assert
 		assert.Error(t, err)
@@ -1401,7 +1397,6 @@ func TestWallet_ContractTransact(t *testing.T) {
 }
 
 func TestWallet_ContractTransactNoWait(t *testing.T) {
-	contract := artifacts.NewPotetoStorage()
 	contractAddress := "0x1234567890123456789012345678901234567890"
 	data := []byte("test data")
 
@@ -1435,7 +1430,6 @@ func TestWallet_ContractTransactNoWait(t *testing.T) {
 			func(
 				_ *ether.Ether,
 				auth *bind.TransactOpts,
-				contract types.ContractInstance,
 				contractAddress string,
 				data []byte,
 			) (*gethTypes.Transaction, error) {
@@ -1444,7 +1438,7 @@ func TestWallet_ContractTransactNoWait(t *testing.T) {
 		)
 
 		// Act
-		tx, err := w.ContractTransactNoWait(contract, contractAddress, data)
+		tx, err := w.ContractTransactNoWait(contractAddress, data)
 
 		// Assert
 		assert.Nil(t, err)
@@ -1455,7 +1449,7 @@ func TestWallet_ContractTransactNoWait(t *testing.T) {
 		w, _ := New(testPrivHex)
 
 		// Act
-		_, err := w.ContractTransactNoWait(contract, contractAddress, data)
+		_, err := w.ContractTransactNoWait(contractAddress, data)
 
 		// Assert
 		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
@@ -1478,7 +1472,7 @@ func TestWallet_ContractTransactNoWait(t *testing.T) {
 		)
 
 		// Act
-		_, err := w.ContractTransactNoWait(contract, contractAddress, data)
+		_, err := w.ContractTransactNoWait(contractAddress, data)
 
 		// Assert
 		assert.Error(t, err)
@@ -1505,7 +1499,6 @@ func TestWallet_ContractTransactNoWait(t *testing.T) {
 			func(
 				_ *ether.Ether,
 				auth *bind.TransactOpts,
-				contract types.ContractInstance,
 				contractAddress string,
 				data []byte,
 			) (*gethTypes.Transaction, error) {
@@ -1514,7 +1507,7 @@ func TestWallet_ContractTransactNoWait(t *testing.T) {
 		)
 
 		// Act
-		_, err := w.ContractTransactNoWait(contract, contractAddress, data)
+		_, err := w.ContractTransactNoWait(contractAddress, data)
 
 		// Assert
 		assert.Error(t, err)
@@ -1745,7 +1738,6 @@ func TestWallet_ResetPool(t *testing.T) {
 
 		// Arrange
 		w := createConnectedWallet()
-		contract := artifacts.NewPotetoStorage()
 		contractAddress := "0x1234567890123456789012345678901234567890"
 		data := []byte("test data")
 
@@ -1766,7 +1758,6 @@ func TestWallet_ResetPool(t *testing.T) {
 			func(
 				_ *ether.Ether,
 				auth *bind.TransactOpts,
-				contract types.ContractInstance,
 				contractAddress string,
 				data []byte,
 			) (*gethTypes.Transaction, error) {
@@ -1775,12 +1766,12 @@ func TestWallet_ResetPool(t *testing.T) {
 		)
 
 		// Act - First call should cache
-		_, err := w.ContractTransactNoWait(contract, contractAddress, data)
+		_, err := w.ContractTransactNoWait(contractAddress, data)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, callCount, "ChainID should be called once")
 
 		// Act - Second call should use cache
-		_, err = w.ContractTransactNoWait(contract, contractAddress, data)
+		_, err = w.ContractTransactNoWait(contractAddress, data)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, callCount, "ChainID should still be called only once (cached)")
 
@@ -1788,7 +1779,7 @@ func TestWallet_ResetPool(t *testing.T) {
 		w.ResetPool()
 
 		// Act - Third call should fetch ChainID again
-		_, err = w.ContractTransactNoWait(contract, contractAddress, data)
+		_, err = w.ContractTransactNoWait(contractAddress, data)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, callCount, "ChainID should be called again after reset")
 	})
@@ -1799,7 +1790,6 @@ func TestWallet_ResetPool(t *testing.T) {
 
 		// Arrange
 		w := createConnectedWallet()
-		contract := artifacts.NewPotetoStorage()
 		contractAddress := "0x1234567890123456789012345678901234567890"
 		data := []byte("test data")
 
@@ -1817,7 +1807,6 @@ func TestWallet_ResetPool(t *testing.T) {
 			func(
 				_ *ether.Ether,
 				auth *bind.TransactOpts,
-				contract types.ContractInstance,
 				contractAddress string,
 				data []byte,
 			) (*gethTypes.Transaction, error) {
@@ -1826,7 +1815,7 @@ func TestWallet_ResetPool(t *testing.T) {
 		)
 
 		// Act - Create cache
-		_, _ = w.ContractTransactNoWait(contract, contractAddress, data)
+		_, _ = w.ContractTransactNoWait(contractAddress, data)
 		assert.NotNil(t, w.cachedChainID, "ChainID should be cached")
 
 		// Act - Reset


### PR DESCRIPTION
## Summary

Closes #430

Removes the `contract types.ContractInstance` parameter from the contract transact APIs. Since `data` is already ABI-encoded by the caller, `bind.Transact` (= `BoundContract.RawTransact`) never uses the ABI — only the contract address and backend are needed.

**Breaking changes:**

```go
// Wallet
ContractTransact(ctx context.Context, contractAddress string, data []byte) (*gethTypes.Receipt, error)
ContractTransactNoWait(contractAddress string, data []byte) (*gethTypes.Transaction, error)

// EtherApi
ContractTransact(auth *bind.TransactOpts, contractAddress string, data []byte) (*gethTypes.Transaction, error)
```

`ContractTransactNoWait` and `EtherApi.ContractTransact` are included because they form the same call chain and the rationale ("you don't need backend abi instance") applies identically.

## Changes

- `ether.ContractTransact` now builds the bound contract internally via `bind.NewBoundContract(addr, abi.ABI{}, c, c, c)` — the same pattern geth's own `bind.DeployContract` uses for pre-encoded input
- Removed the now-unreachable nil-contract check and the dead `constant.ErrContractInstanceIsNil`
- Updated unit tests (wallet, ether, race) for the new signatures
- Added e2e scenario `TestScenario_ContractTransact`: deploy PotetoStorage → `store(42)` via new API → verify with `retrieve`
- Updated docs: `ContractTransact.md`, `ContractTransactNoWait.md`, `ResetPool.md`

## Testing

- `just ut` — all packages pass
- e2e (`RPC_PORT=32769 go test ./e2e/ -count=1`) — full suite passes against kurtosis chain, including the new scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)