### PR TITLE
:boom: feat: remove ContractInstance param from ContractCall. refs: #433

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,12 +49,6 @@ jobs:
           path: coverage.out
           retention-days: 1
 
-  anvil-up:
-    runs-on: ubuntu-latest
-    container: ghcr.io/foundry-rs/foundry:latest
-    steps:
-      - name: anvil up
-
   e2e-test:
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,12 @@ jobs:
           path: coverage.out
           retention-days: 1
 
+  anvil-up:
+    runs-on: ubuntu-latest
+    container: ghcr.io/foundry-rs/foundry:latest
+    steps:
+      - name: anvil up
+
   e2e-test:
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/docs/docs/wallet/ContractCall.md
+++ b/docs/docs/wallet/ContractCall.md
@@ -18,7 +18,6 @@ you can use factory pattern for more type safety.
 ```go
 func ContractCall[T any](
 	w wallet.Wallet,
-	contract types.ContractInstance,
 	contractAddress string,
 	opts *bind.CallOpts,
 	callData []byte,
@@ -50,7 +49,7 @@ func main() {
 	}
 
 	// Execute call
-	result, err := factory.ContractCall(w, contract, contractAddress, nil, data, unpack)
+	result, err := factory.ContractCall(w, contractAddress, nil, data, unpack)
 	if err != nil {
 		panic(err)
 	}
@@ -70,7 +69,6 @@ func main() {
 
 ```go
 func ContractCall(
-	contract types.ContractInstance,
 	contractAddress string,
 	opts *bind.CallOpts,
 	callData []byte,
@@ -102,7 +100,7 @@ func main() {
 	}
 
 	// Execute call
-	result, err := w.ContractCall(contract, contractAddress, nil, data, unpack)
+	result, err := w.ContractCall(contractAddress, nil, data, unpack)
 	if err != nil {
 		panic(err)
 	}

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -221,7 +221,6 @@ func TestScenario_ContractTransact(t *testing.T) {
 
 		// verify stored value via retrieve
 		res, err := w.ContractCall(
-			contract,
 			contractAddress.Hex(),
 			&bind.CallOpts{},
 			contract.PackRetrieve(),

--- a/ether/ether.go
+++ b/ether/ether.go
@@ -777,6 +777,13 @@ func (ether *Ether) DeployContract(
 	return deployRes, err
 }
 
+// rawBoundContract binds the address to the backend with an empty ABI.
+// Callers pass pre-encoded data and decode results themselves, so bind
+// only needs the address and backend.
+func rawBoundContract(addr common.Address, backend bind.ContractBackend) *bind.BoundContract {
+	return bind.NewBoundContract(addr, abi.ABI{}, backend, backend, backend)
+}
+
 // TODO: backoff
 func (ether *Ether) ContractTransact(auth *bind.TransactOpts, contractAddress string, data []byte) (*gethTypes.Transaction, error) {
 	err := ether.SetEthClient()
@@ -785,9 +792,7 @@ func (ether *Ether) ContractTransact(auth *bind.TransactOpts, contractAddress st
 	}
 	defer ether.Close()
 
-	// data is already ABI-encoded, so bind only needs the address and backend.
-	c := ether.Client()
-	instance := bind.NewBoundContract(common.HexToAddress(contractAddress), abi.ABI{}, c, c, c)
+	instance := rawBoundContract(common.HexToAddress(contractAddress), ether.Client())
 
 	tx, err := bind.Transact(
 		instance, auth, data,
@@ -835,7 +840,6 @@ func (ether *Ether) WaitDeployed(ctx context.Context, txHash common.Hash) (commo
 func (
 	ether *Ether,
 ) ContractCall(
-	contract types.ContractInstance,
 	contractAddress common.Address,
 	opts *bind.CallOpts,
 	callData []byte,
@@ -847,8 +851,7 @@ func (
 	}
 	defer ether.Close()
 
-	c := ether.Client()
-	instance := contract.Instance(c, contractAddress)
+	instance := rawBoundContract(contractAddress, ether.Client())
 
 	val, err := bind.Call(instance, opts, callData, unpack)
 	if err != nil {

--- a/ether/ether_transact_test.go
+++ b/ether/ether_transact_test.go
@@ -7,24 +7,14 @@ import (
 	"testing"
 
 	"math/big"
-	"strings"
 
 	"github.com/agiledragon/gomonkey"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	eth "github.com/poteto-go/go-alchemy-sdk/ether"
 	"github.com/stretchr/testify/assert"
 )
-
-type mockContract struct {
-	abi abi.ABI
-}
-
-func (m *mockContract) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {
-	return bind.NewBoundContract(addr, m.abi, backend, backend, backend)
-}
 
 func TestEther_ContractCall(t *testing.T) {
 	t.Run("normal case", func(t *testing.T) {
@@ -33,12 +23,6 @@ func TestEther_ContractCall(t *testing.T) {
 		alchemyMock := newAlchemyMockOnEtherTest(t)
 		defer alchemyMock.DeactivateAndReset()
 
-		// Mock ABI
-		abiJSON := `[{"constant":true,"inputs":[],"name":"test","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"}]`
-		parsedABI, err := abi.JSON(strings.NewReader(abiJSON))
-		assert.NoError(t, err)
-
-		mockInstance := &mockContract{abi: parsedABI}
 		addr := common.HexToAddress("0x123")
 
 		expectedVal := big.NewInt(1)
@@ -52,7 +36,7 @@ func TestEther_ContractCall(t *testing.T) {
 		callData := []byte{0x12, 0x34}
 
 		// Act
-		res, err := ether.ContractCall(mockInstance, addr, nil, callData, unpack)
+		res, err := ether.ContractCall(addr, nil, callData, unpack)
 
 		// Assert
 		assert.NoError(t, err)
@@ -77,15 +61,12 @@ func TestEther_ContractCall(t *testing.T) {
 			)
 
 			// Mock objects
-			abiJSON := `[]`
-			parsedABI, _ := abi.JSON(strings.NewReader(abiJSON))
-			mockInstance := &mockContract{abi: parsedABI}
 			addr := common.HexToAddress("0x123")
 			callData := []byte{}
 			unpack := func(b []byte) (any, error) { return nil, nil }
 
 			// Act
-			res, err := ether.ContractCall(mockInstance, addr, nil, callData, unpack)
+			res, err := ether.ContractCall(addr, nil, callData, unpack)
 
 			// Assert
 			assert.Error(t, err)
@@ -102,15 +83,12 @@ func TestEther_ContractCall(t *testing.T) {
 			alchemyMock.RegisterResponderOnce("eth_call", `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"execution reverted"}}`)
 
 			// Mock objects
-			abiJSON := `[{"constant":true,"inputs":[],"name":"test","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"}]`
-			parsedABI, _ := abi.JSON(strings.NewReader(abiJSON))
-			mockInstance := &mockContract{abi: parsedABI}
 			addr := common.HexToAddress("0x123")
 			callData := []byte{0x12, 0x34}
 			unpack := func(b []byte) (any, error) { return nil, nil }
 
 			// Act
-			res, err := ether.ContractCall(mockInstance, addr, nil, callData, unpack)
+			res, err := ether.ContractCall(addr, nil, callData, unpack)
 
 			// Assert
 			assert.Error(t, err)

--- a/factory/wallet_factory.go
+++ b/factory/wallet_factory.go
@@ -9,13 +9,12 @@ import (
 
 func ContractCall[T any](
 	w types.Wallet,
-	contract types.ContractInstance,
 	contractAddress string,
 	opts *bind.CallOpts,
 	callData []byte,
 	unpack func([]byte) (T, error),
 ) (T, error) {
-	res, err := w.ContractCall(contract, contractAddress, opts, callData, func(b []byte) (any, error) {
+	res, err := w.ContractCall(contractAddress, opts, callData, func(b []byte) (any, error) {
 		return unpack(b)
 	})
 	if err != nil {

--- a/factory/wallet_factory_test.go
+++ b/factory/wallet_factory_test.go
@@ -17,7 +17,6 @@ type mockWallet struct {
 }
 
 func (m *mockWallet) ContractCall(
-	contract types.ContractInstance,
 	contractAddress string,
 	opts *bind.CallOpts,
 	callData []byte,
@@ -35,7 +34,7 @@ func TestContractCall(t *testing.T) {
 		}
 
 		// Act
-		res, err := ContractCall(w, nil, "0x123", nil, nil, unpack)
+		res, err := ContractCall(w, "0x123", nil, nil, unpack)
 
 		// Assert
 		assert.NoError(t, err)
@@ -53,7 +52,6 @@ func TestContractCall(t *testing.T) {
 			"ContractCall",
 			func(
 				_ *mockWallet,
-				_ types.ContractInstance,
 				_ string,
 				_ *bind.CallOpts,
 				_ []byte,
@@ -68,7 +66,7 @@ func TestContractCall(t *testing.T) {
 		}
 
 		// Act
-		_, err := ContractCall(w, nil, "0x123", nil, nil, unpack)
+		_, err := ContractCall(w, "0x123", nil, nil, unpack)
 
 		// Assert
 		assert.Error(t, err)
@@ -85,7 +83,6 @@ func TestContractCall(t *testing.T) {
 			"ContractCall",
 			func(
 				_ *mockWallet,
-				_ types.ContractInstance,
 				_ string,
 				_ *bind.CallOpts,
 				_ []byte,
@@ -100,7 +97,7 @@ func TestContractCall(t *testing.T) {
 		}
 
 		// Act
-		_, err := ContractCall(w, nil, "0x123", nil, nil, unpack)
+		_, err := ContractCall(w, "0x123", nil, nil, unpack)
 
 		// Assert
 		assert.Error(t, err)

--- a/types/ether_api.go
+++ b/types/ether_api.go
@@ -12,18 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-type ContractInstance interface {
-	Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract
-}
-
-type ERC20ContractInstance interface {
-	ContractInstance
-	PackBalanceOf(walletAddress common.Address) []byte
-	UnpackBalanceOf(data []byte) (*big.Int, error)
-	PackTransfer(to common.Address, amount *big.Int) []byte
-	UnpackTransfer(data []byte) (bool, error)
-}
-
 type EtherApi interface {
 	/*
 		set ether client if client is nil,
@@ -247,7 +235,6 @@ type EtherApi interface {
 		internal call geth
 	*/
 	ContractCall(
-		contract ContractInstance,
 		contractAddress common.Address,
 		ops *bind.CallOpts,
 		callData []byte,

--- a/types/wallet.go
+++ b/types/wallet.go
@@ -91,7 +91,6 @@ type Wallet interface {
 		It is used for read-only methods.
 	*/
 	ContractCall(
-		contract ContractInstance,
 		contractAddress string,
 		opts *bind.CallOpts,
 		callData []byte,

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -275,7 +275,6 @@ func (w *wallet) ContractTransactNoWait(
 }
 
 func (w *wallet) ContractCall(
-	contract types.ContractInstance,
 	contractAddress string,
 	opts *bind.CallOpts,
 	callData []byte,
@@ -287,7 +286,7 @@ func (w *wallet) ContractCall(
 	}
 
 	addr := common.HexToAddress(contractAddress)
-	return provider.Eth().ContractCall(contract, addr, opts, callData, unpack)
+	return provider.Eth().ContractCall(addr, opts, callData, unpack)
 }
 
 func (w *wallet) SignEIP712(domainSeparator [32]byte, encoded []byte) (types.Signature, error) {

--- a/wallet/wallet_race_test.go
+++ b/wallet/wallet_race_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/poteto-go/go-alchemy-sdk/_fixture/artifacts"
 	"github.com/poteto-go/go-alchemy-sdk/ether"
 	"github.com/poteto-go/go-alchemy-sdk/gas"
 	"github.com/poteto-go/go-alchemy-sdk/namespace"
@@ -76,7 +75,6 @@ func TestWallet_NoRaceConnectVsReaders(t *testing.T) {
 		"ContractCall",
 		func(
 			_ *ether.Ether,
-			_ types.ContractInstance,
 			_ common.Address,
 			_ *bind.CallOpts,
 			_ []byte,
@@ -114,7 +112,6 @@ func TestWallet_NoRaceConnectVsReaders(t *testing.T) {
 	w, _ := New(testPrivHex)
 	w.Connect(provider) // ensure erc20 is set before readers start
 
-	contract := artifacts.NewPotetoStorage()
 	contractAddress := "0x1234567890123456789012345678901234567890"
 	callData := []byte("call data")
 	callOpts := &bind.CallOpts{}
@@ -155,7 +152,7 @@ func TestWallet_NoRaceConnectVsReaders(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < iterations; i++ {
-			_, _ = w.ContractCall(contract, contractAddress, callOpts, callData, unpack)
+			_, _ = w.ContractCall(contractAddress, callOpts, callData, unpack)
 		}
 	}()
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1515,7 +1515,6 @@ func TestWallet_ContractTransactNoWait(t *testing.T) {
 }
 
 func TestWallet_ContractCall(t *testing.T) {
-	contract := artifacts.NewPotetoStorage()
 	contractAddress := "0x1234567890123456789012345678901234567890"
 	data := []byte("test data")
 	unpack := func(b []byte) (any, error) { return nil, nil }
@@ -1535,7 +1534,6 @@ func TestWallet_ContractCall(t *testing.T) {
 			"ContractCall",
 			func(
 				_ *ether.Ether,
-				_ types.ContractInstance,
 				_ common.Address,
 				_ *bind.CallOpts,
 				_ []byte,
@@ -1546,7 +1544,7 @@ func TestWallet_ContractCall(t *testing.T) {
 		)
 
 		// Act
-		res, err := w.ContractCall(contract, contractAddress, callOpts, data, unpack)
+		res, err := w.ContractCall(contractAddress, callOpts, data, unpack)
 
 		// Assert
 		assert.Nil(t, err)
@@ -1557,7 +1555,7 @@ func TestWallet_ContractCall(t *testing.T) {
 		w, _ := New(testPrivHex)
 
 		// Act
-		_, err := w.ContractCall(contract, contractAddress, callOpts, data, unpack)
+		_, err := w.ContractCall(contractAddress, callOpts, data, unpack)
 
 		// Assert
 		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
@@ -1576,7 +1574,6 @@ func TestWallet_ContractCall(t *testing.T) {
 			"ContractCall",
 			func(
 				_ *ether.Ether,
-				_ types.ContractInstance,
 				_ common.Address,
 				_ *bind.CallOpts,
 				_ []byte,
@@ -1587,7 +1584,7 @@ func TestWallet_ContractCall(t *testing.T) {
 		)
 
 		// Act
-		_, err := w.ContractCall(contract, contractAddress, callOpts, data, unpack)
+		_, err := w.ContractCall(contractAddress, callOpts, data, unpack)
 
 		// Assert
 		assert.Error(t, err)


### PR DESCRIPTION
## Summary

Closes #433

Removes the `contract types.ContractInstance` parameter from the contract call APIs, mirroring #430 (#432). `callData` is already ABI-encoded by the caller and `unpack` is caller-supplied, so `bind.Call` (= `BoundContract.CallRaw`) never uses the ABI — only the contract address and backend are needed.

**Breaking changes:**

```go
// Wallet
ContractCall(contractAddress string, opts *bind.CallOpts, callData []byte, unpack func([]byte) (any, error)) (any, error)

// EtherApi
ContractCall(contractAddress common.Address, opts *bind.CallOpts, callData []byte, unpack func([]byte) (any, error)) (any, error)

// factory
ContractCall[T any](w types.Wallet, contractAddress string, opts *bind.CallOpts, callData []byte, unpack func([]byte) (T, error)) (T, error)
```

- Removed `types.ContractInstance` / `types.ERC20ContractInstance` — this PR removed the last reference to `ContractInstance` (`ERC20ContractInstance` embeds it and was already unreferenced)

## Changes

- `ether.ContractCall` builds the bound contract internally; extracted shared `rawBoundContract` helper now used by both `ContractCall` and `ContractTransact`
- Updated unit tests (ether, wallet, race, factory) and removed the now-unneeded `mockContract` fixture / ABI parsing in tests
- Updated e2e `TestScenario_ContractTransact` to the new `ContractCall` signature (still verifies `store(42)` → `retrieve`)
- Updated docs: `ContractCall.md` (factory & wallet sections)

## Testing

- `just ut` — all packages pass
- e2e full suite passes against kurtosis chain (`RPC_PORT=32769 go test ./e2e/ -count=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
