### PR TITLE
feat: call basic ERC721 read methods on wallet Nft namespace. refs: #423

### DIFF
--- a/docs/docs/wallet/Nft.md
+++ b/docs/docs/wallet/Nft.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 20
+---
+
+# Nft
+
+You can execute basic NFT (ERC721) read methods from the specified wallet.
+Each method delegates to the [Nft namespace](../nft-namespace/OwnerOf.md).
+
+:::note
+
+Since it performs calls via bytecode, it does not require the contract implementation and can be called as long as the address is available.
+
+:::
+
+:::warning
+
+- It requires connected wallet.
+- It does not work on non-Ethereum compatible networks.
+
+:::
+
+```go
+func main() {
+	alchemy = gas.NewAlchemy(setting)
+	w, _ := wallet.New("<privateKey>")
+	w.Connect(alchemy.GetProvider())
+
+	// call each method
+	w.Nft().MethodXXX()
+}
+```
+
+## Read Methods
+
+You can fetch NFT collection metadata and ownership / approval information:
+
+- [OwnerOf](../nft-namespace/OwnerOf.md)
+- [TokenURI](../nft-namespace/TokenURI.md)
+- [Name](../nft-namespace/Name.md)
+- [Symbol](../nft-namespace/Symbol.md)
+- [GetApproved](../nft-namespace/GetApproved.md)
+- [IsApprovedForAll](../nft-namespace/IsApprovedForAll.md)
+
+```go
+owner, err := w.Nft().OwnerOf("<contractAddress>", big.NewInt(1))
+uri, err := w.Nft().TokenURI("<contractAddress>", big.NewInt(1))
+name, err := w.Nft().Name("<contractAddress>")
+symbol, err := w.Nft().Symbol("<contractAddress>")
+approved, err := w.Nft().GetApproved("<contractAddress>", big.NewInt(1))
+isApproved, err := w.Nft().IsApprovedForAll("<contractAddress>", "<owner>", "<operator>")
+```

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -985,6 +985,23 @@ func TestScenario_Nft(t *testing.T) {
 			assert.Nil(t, err)
 			assert.True(t, isApproved)
 		})
+
+		// The wallet Nft namespace delegates to alchemy.Nft (verified in detail
+		// above), so a few representative reads are enough to prove the wiring.
+		t.Run("can call read methods via wallet Nft namespace", func(t *testing.T) {
+			name, err := w.Nft().Name(contractHex)
+			assert.Nil(t, err)
+			assert.Equal(t, "Minimal NFT", name)
+
+			owner, err := w.Nft().OwnerOf(contractHex, tokenId)
+			assert.Nil(t, err)
+			assert.Equal(t, strings.ToLower(initAddress), owner)
+
+			// setApprovalForAll(otherAddress, true) was executed in the earlier subtest.
+			isApproved, err := w.Nft().IsApprovedForAll(contractHex, initAddress, otherAddress)
+			assert.Nil(t, err)
+			assert.True(t, isApproved)
+		})
 	})
 }
 

--- a/types/wallet.go
+++ b/types/wallet.go
@@ -115,6 +115,9 @@ type Wallet interface {
 	/* StableCoin support */
 	StableCoin() WalletStableCoin
 
+	/* Nft (ERC721) support */
+	Nft() WalletNft
+
 	/*
 		ResetPool clears the cached ChainID and TransactOpts.
 		Call this when you need to refresh the cached values.

--- a/types/wallet_nft.go
+++ b/types/wallet_nft.go
@@ -1,0 +1,39 @@
+package types
+
+import (
+	"math/big"
+)
+
+// Nft (ERC721) interface for wallet.
+// This is only defined for UX.
+type WalletNft interface {
+	/*
+		get owner of the NFT with the given tokenId
+	*/
+	OwnerOf(contractAddress string, tokenId *big.Int) (string, error)
+
+	/*
+		get URI of the NFT metadata for the given tokenId
+	*/
+	TokenURI(contractAddress string, tokenId *big.Int) (string, error)
+
+	/*
+		get name of the NFT collection
+	*/
+	Name(contractAddress string) (string, error)
+
+	/*
+		get symbol of the NFT collection
+	*/
+	Symbol(contractAddress string) (string, error)
+
+	/*
+		get approved address for the given tokenId
+	*/
+	GetApproved(contractAddress string, tokenId *big.Int) (string, error)
+
+	/*
+		get whether the operator is approved to manage all of the owner's NFTs
+	*/
+	IsApprovedForAll(contractAddress, owner, operator string) (bool, error)
+}

--- a/wallet/nft.go
+++ b/wallet/nft.go
@@ -1,0 +1,65 @@
+package wallet
+
+import (
+	"math/big"
+
+	"github.com/poteto-go/go-alchemy-sdk/constant"
+)
+
+type walletNft struct {
+	w *wallet
+}
+
+func (api *walletNft) OwnerOf(contractAddress string, tokenId *big.Int) (string, error) {
+	nft := api.w.snapshotNft()
+	if nft == nil {
+		return "", constant.ErrWalletIsNotConnected
+	}
+
+	return nft.OwnerOf(contractAddress, tokenId)
+}
+
+func (api *walletNft) TokenURI(contractAddress string, tokenId *big.Int) (string, error) {
+	nft := api.w.snapshotNft()
+	if nft == nil {
+		return "", constant.ErrWalletIsNotConnected
+	}
+
+	return nft.TokenURI(contractAddress, tokenId)
+}
+
+func (api *walletNft) Name(contractAddress string) (string, error) {
+	nft := api.w.snapshotNft()
+	if nft == nil {
+		return "", constant.ErrWalletIsNotConnected
+	}
+
+	return nft.Name(contractAddress)
+}
+
+func (api *walletNft) Symbol(contractAddress string) (string, error) {
+	nft := api.w.snapshotNft()
+	if nft == nil {
+		return "", constant.ErrWalletIsNotConnected
+	}
+
+	return nft.Symbol(contractAddress)
+}
+
+func (api *walletNft) GetApproved(contractAddress string, tokenId *big.Int) (string, error) {
+	nft := api.w.snapshotNft()
+	if nft == nil {
+		return "", constant.ErrWalletIsNotConnected
+	}
+
+	return nft.GetApproved(contractAddress, tokenId)
+}
+
+func (api *walletNft) IsApprovedForAll(contractAddress, owner, operator string) (bool, error) {
+	nft := api.w.snapshotNft()
+	if nft == nil {
+		return false, constant.ErrWalletIsNotConnected
+	}
+
+	return nft.IsApprovedForAll(contractAddress, owner, operator)
+}

--- a/wallet/nft_test.go
+++ b/wallet/nft_test.go
@@ -1,0 +1,192 @@
+package wallet
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/agiledragon/gomonkey"
+	"github.com/poteto-go/go-alchemy-sdk/constant"
+	"github.com/poteto-go/go-alchemy-sdk/namespace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWallet_NftReadMethods(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	ownerAddress := "0xE25583099BA105D9ec0A67f5Ae86D90e50036425"
+	operatorAddress := "0xAbcdef1234567890abcdef1234567890AbCdEf12"
+	tokenId := big.NewInt(1)
+
+	t.Run("can get owner of token", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange
+		w := createConnectedWallet()
+		expected := "0xe25583099ba105d9ec0a67f5ae86d90e50036425"
+
+		// Mock
+		patches.ApplyMethod(reflect.TypeOf(w.nft), "OwnerOf", func(_ *namespace.Nft, _ string, _ *big.Int) (string, error) {
+			return expected, nil
+		})
+
+		// Act
+		res, err := w.Nft().OwnerOf(contractAddress, tokenId)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, expected, res)
+	})
+
+	t.Run("can get token URI", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange
+		w := createConnectedWallet()
+		expected := "https://example.com/nft/1"
+
+		// Mock
+		patches.ApplyMethod(reflect.TypeOf(w.nft), "TokenURI", func(_ *namespace.Nft, _ string, _ *big.Int) (string, error) {
+			return expected, nil
+		})
+
+		// Act
+		res, err := w.Nft().TokenURI(contractAddress, tokenId)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, expected, res)
+	})
+
+	t.Run("can get name", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange
+		w := createConnectedWallet()
+		expected := "TestNFT"
+
+		// Mock
+		patches.ApplyMethod(reflect.TypeOf(w.nft), "Name", func(_ *namespace.Nft, _ string) (string, error) {
+			return expected, nil
+		})
+
+		// Act
+		res, err := w.Nft().Name(contractAddress)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, expected, res)
+	})
+
+	t.Run("can get symbol", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange
+		w := createConnectedWallet()
+		expected := "TNFT"
+
+		// Mock
+		patches.ApplyMethod(reflect.TypeOf(w.nft), "Symbol", func(_ *namespace.Nft, _ string) (string, error) {
+			return expected, nil
+		})
+
+		// Act
+		res, err := w.Nft().Symbol(contractAddress)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, expected, res)
+	})
+
+	t.Run("can get approved address", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange
+		w := createConnectedWallet()
+		expected := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+		// Mock
+		patches.ApplyMethod(reflect.TypeOf(w.nft), "GetApproved", func(_ *namespace.Nft, _ string, _ *big.Int) (string, error) {
+			return expected, nil
+		})
+
+		// Act
+		res, err := w.Nft().GetApproved(contractAddress, tokenId)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, expected, res)
+	})
+
+	t.Run("can get isApprovedForAll", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange
+		w := createConnectedWallet()
+
+		// Mock
+		patches.ApplyMethod(reflect.TypeOf(w.nft), "IsApprovedForAll", func(_ *namespace.Nft, _, _, _ string) (bool, error) {
+			return true, nil
+		})
+
+		// Act
+		res, err := w.Nft().IsApprovedForAll(contractAddress, ownerAddress, operatorAddress)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.True(t, res)
+	})
+
+	t.Run("error w/o connect wallet on OwnerOf", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.Nft().OwnerOf(contractAddress, tokenId)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+
+	t.Run("error w/o connect wallet on TokenURI", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.Nft().TokenURI(contractAddress, tokenId)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+
+	t.Run("error w/o connect wallet on Name", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.Nft().Name(contractAddress)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+
+	t.Run("error w/o connect wallet on Symbol", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.Nft().Symbol(contractAddress)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+
+	t.Run("error w/o connect wallet on GetApproved", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.Nft().GetApproved(contractAddress, tokenId)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+
+	t.Run("error w/o connect wallet on IsApprovedForAll", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.Nft().IsApprovedForAll(contractAddress, ownerAddress, operatorAddress)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -32,9 +32,10 @@ type wallet struct {
 	cachedChainID *big.Int
 	legacyChain   bool
 
-	// for ERC20 / StableCoin
+	// for ERC20 / StableCoin / Nft
 	erc20      namespace.IERC20
 	stablecoin namespace.IStableCoin
+	nft        namespace.INft
 }
 
 func New(privateKeyStr string) (types.Wallet, error) {
@@ -81,6 +82,12 @@ func (w *wallet) snapshotStableCoin() namespace.IStableCoin {
 	return w.stablecoin
 }
 
+func (w *wallet) snapshotNft() namespace.INft {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.nft
+}
+
 func (w *wallet) GetBalance() (*big.Int, error) {
 	provider := w.snapshot()
 	if provider == nil {
@@ -101,6 +108,7 @@ func (w *wallet) Connect(provider types.IAlchemyProvider) {
 	w.provider = provider
 	w.erc20 = namespace.NewERC20Namespace(provider.Eth())
 	w.stablecoin = namespace.NewStableCoinNamespace(provider.Eth())
+	w.nft = namespace.NewNftNamespace(provider.Eth())
 }
 
 func (w *wallet) PendingNonceAt() (uint64, error) {
@@ -299,6 +307,10 @@ func (w *wallet) ERC20() types.WalletERC20 {
 
 func (w *wallet) StableCoin() types.WalletStableCoin {
 	return &walletStableCoin{walletERC20{w: w}}
+}
+
+func (w *wallet) Nft() types.WalletNft {
+	return &walletNft{w: w}
 }
 
 func (w *wallet) buildAuth() (*bind.TransactOpts, error) {

--- a/wallet/wallet_race_test.go
+++ b/wallet/wallet_race_test.go
@@ -265,3 +265,102 @@ func TestWallet_NoRaceConnectVsERC20Readers(t *testing.T) {
 
 	wg.Wait()
 }
+
+// TestWallet_NoRaceConnectVsNftReaders verifies that concurrent Connect
+// calls do not race with walletNft readers that touch w.nft.
+// Refs: https://github.com/poteto-go/go-alchemy-sdk/issues/332
+func TestWallet_NoRaceConnectVsNftReaders(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	setting := gas.AlchemySetting{
+		ApiKey:  "api-key",
+		Network: types.EthMainnet,
+	}
+	alchemy, err := gas.NewAlchemy(setting)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := alchemy.GetProvider()
+
+	patches.ApplyMethod(
+		reflect.TypeOf(&namespace.Nft{}),
+		"OwnerOf",
+		func(_ *namespace.Nft, _ string, _ *big.Int) (string, error) {
+			return "", nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(&namespace.Nft{}),
+		"TokenURI",
+		func(_ *namespace.Nft, _ string, _ *big.Int) (string, error) {
+			return "", nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(&namespace.Nft{}),
+		"Name",
+		func(_ *namespace.Nft, _ string) (string, error) {
+			return "", nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(&namespace.Nft{}),
+		"Symbol",
+		func(_ *namespace.Nft, _ string) (string, error) {
+			return "", nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(&namespace.Nft{}),
+		"GetApproved",
+		func(_ *namespace.Nft, _ string, _ *big.Int) (string, error) {
+			return "", nil
+		},
+	)
+	patches.ApplyMethod(
+		reflect.TypeOf(&namespace.Nft{}),
+		"IsApprovedForAll",
+		func(_ *namespace.Nft, _, _, _ string) (bool, error) {
+			return false, nil
+		},
+	)
+
+	w, _ := New(testPrivHex)
+	w.Connect(provider)
+
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	tokenId := big.NewInt(1)
+
+	const iterations = 200
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			w.Connect(provider)
+		}
+	}()
+
+	readers := []func(){
+		func() { _, _ = w.Nft().OwnerOf(contractAddress, tokenId) },
+		func() { _, _ = w.Nft().TokenURI(contractAddress, tokenId) },
+		func() { _, _ = w.Nft().Name(contractAddress) },
+		func() { _, _ = w.Nft().Symbol(contractAddress) },
+		func() { _, _ = w.Nft().GetApproved(contractAddress, tokenId) },
+		func() { _, _ = w.Nft().IsApprovedForAll(contractAddress, contractAddress, contractAddress) },
+	}
+
+	for _, r := range readers {
+		wg.Add(1)
+		go func(read func()) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				read()
+			}
+		}(r)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Part of #423 (read methods only — write methods will follow in a separate PR).

Adds the `Wallet.Nft()` namespace, mirroring `Wallet.ERC20()` (#294):

- `types.WalletNft` interface (`types/wallet_nft.go`), role-segregated from the start (#387)
- `wallet/nft.go` — read methods delegating to the `Nft` namespace (#431): `OwnerOf`, `TokenURI`, `Name`, `Symbol`, `GetApproved`, `IsApprovedForAll`
- `Wallet.Nft()` accessor; the underlying `namespace.INft` is set in `Connect` and read through a lock-guarded `snapshotNft()` (#332)

## Testing

- Unit: `wallet/nft_test.go` — delegation + `ErrWalletIsNotConnected` for all six methods (TDD)
- Race: `TestWallet_NoRaceConnectVsNftReaders` (mirrors the ERC20 race test), passes with `-race`
- E2E: representative wallet reads added to `TestScenario_Nft`, suite passes against local anvil
- `just ut` and `just lint` clean

## Docs

- `docs/docs/wallet/Nft.md` linking to the nft-namespace method docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)