### PR TITLE
feat: Wallet.Nft Approve / SetApprovalForAll (#425)

### DIFF
--- a/constant/contract_methods.go
+++ b/constant/contract_methods.go
@@ -43,6 +43,9 @@ var (
 	IsApprovedForAllFnSignature         = []byte("isApprovedForAll(address,address)")
 	SafeTransferFromFnSignature         = []byte("safeTransferFrom(address,address,uint256)")
 	SafeTransferFromWithDataFnSignature = []byte("safeTransferFrom(address,address,uint256,bytes)")
+	SetApprovalForAllFnSignature        = []byte("setApprovalForAll(address,bool)")
+	// NOTE: ERC-721 approve(to, tokenId) has the same selector as ERC-20's
+	// approve(address,uint256), so it reuses ApproveFnSignature above.
 
 	// EIP-2612
 	PermitFnSignature          = []byte("permit(address,address,uint256,uint256,uint8,bytes32,bytes32)")

--- a/docs/docs/wallet/Nft.md
+++ b/docs/docs/wallet/Nft.md
@@ -114,3 +114,40 @@ receipt, err := w.Nft().SafeTransferFromWithData(
 
 txHash, err := w.Nft().SafeTransferFromWithDataNoWait("<contractAddress>", "<fromAddress>", "<toAddress>", big.NewInt(1), data, nil)
 ```
+
+### Approve & ApproveNoWait
+
+Approve another address to transfer the NFT with the given `tokenId`. The
+approval is cleared automatically when the token is transferred.
+
+```go
+receipt, err := w.Nft().Approve(
+	context.Background(),
+	"<contractAddress>",
+	"<toAddress>",
+	big.NewInt(1),
+	nil,
+)
+
+// or without waiting for the receipt
+txHash, err := w.Nft().ApproveNoWait("<contractAddress>", "<toAddress>", big.NewInt(1), nil)
+```
+
+### SetApprovalForAll & SetApprovalForAllNoWait
+
+Grant or revoke an operator's approval to manage **all** of the connected
+wallet's NFTs in the collection. Pass `approved=true` to grant and `false` to
+revoke.
+
+```go
+receipt, err := w.Nft().SetApprovalForAll(
+	context.Background(),
+	"<contractAddress>",
+	"<operatorAddress>",
+	true,
+	nil,
+)
+
+// or without waiting for the receipt
+txHash, err := w.Nft().SetApprovalForAllNoWait("<contractAddress>", "<operatorAddress>", true, nil)
+```

--- a/e2e/simulated_test.go
+++ b/e2e/simulated_test.go
@@ -489,6 +489,36 @@ func TestSimulated_Nft(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, strings.ToLower(otherAddress), owner)
 		})
+
+		t.Run("can approve & setApprovalForAll via wallet Nft namespace", func(t *testing.T) {
+			otherWallet, err := wallet.New(otherPrivateKey)
+			assert.Nil(t, err)
+			otherWallet.Connect(alchemy.GetProvider())
+
+			// Token 1 is currently owned by otherAddress; approve initAddress.
+			_, err = otherWallet.Nft().Approve(context.Background(), contractHex, initAddress, tokenId, nil)
+			assert.Nil(t, err)
+
+			approved, err := w.Nft().GetApproved(contractHex, tokenId)
+			assert.Nil(t, err)
+			assert.Equal(t, strings.ToLower(initAddress), approved)
+
+			// Grant initAddress operator approval over all of otherAddress's NFTs.
+			_, err = otherWallet.Nft().SetApprovalForAll(context.Background(), contractHex, initAddress, true, nil)
+			assert.Nil(t, err)
+
+			isApproved, err := w.Nft().IsApprovedForAll(contractHex, otherAddress, initAddress)
+			assert.Nil(t, err)
+			assert.True(t, isApproved)
+
+			// Revoke it again.
+			_, err = otherWallet.Nft().SetApprovalForAll(context.Background(), contractHex, initAddress, false, nil)
+			assert.Nil(t, err)
+
+			isApproved, err = w.Nft().IsApprovedForAll(contractHex, otherAddress, initAddress)
+			assert.Nil(t, err)
+			assert.False(t, isApproved)
+		})
 	})
 }
 

--- a/encode/abi.go
+++ b/encode/abi.go
@@ -50,6 +50,16 @@ func ABIUint256(v *big.Int) []byte {
 	return common.LeftPadBytes(v.Bytes(), constant.ABIWordSize)
 }
 
+// ABIBool encodes a bool as a 32-byte ABI word (0x00..01 for true, all zeros
+// for false).
+func ABIBool(v bool) []byte {
+	b := make([]byte, constant.ABIWordSize)
+	if v {
+		b[constant.ABIWordSize-1] = 1
+	}
+	return b
+}
+
 // ABIBytes encodes the tail of a dynamic `bytes` argument: a 32-byte length
 // word followed by the data right-padded to a word boundary. The caller is
 // responsible for emitting the preceding offset word that points at this tail.

--- a/encode/abi_test.go
+++ b/encode/abi_test.go
@@ -109,3 +109,20 @@ func TestABIUint256(t *testing.T) {
 		assert.Equal(t, 0, v.Cmp(decoded))
 	})
 }
+
+func TestABIBool(t *testing.T) {
+	t.Run("encodes true to 0x00..01", func(t *testing.T) {
+		out := encode.ABIBool(true)
+
+		assert.Equal(t, constant.ABIWordSize, len(out))
+		assert.Equal(t, make([]byte, 31), out[:31])
+		assert.Equal(t, byte(0x01), out[31])
+	})
+
+	t.Run("encodes false to all zeros", func(t *testing.T) {
+		out := encode.ABIBool(false)
+
+		assert.Equal(t, constant.ABIWordSize, len(out))
+		assert.Equal(t, make([]byte, 32), out)
+	})
+}

--- a/types/wallet_nft.go
+++ b/types/wallet_nft.go
@@ -56,6 +56,34 @@ type WalletNft interface {
 	SafeTransferFromWithDataNoWait(contractAddress, fromAddress, toAddress string, tokenId *big.Int, data []byte, gasLimit *uint64) (common.Hash, error)
 
 	/*
+		approve another address to transfer the NFT with the given tokenId
+			- wait for mined
+			- gas limit is 300000 for default
+			- stops waiting when ctx is canceled
+	*/
+	Approve(ctx context.Context, contractAddress, toAddress string, tokenId *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error)
+
+	/*
+		approve another address to transfer the NFT with the given tokenId
+			- gas limit is 300000 for default
+	*/
+	ApproveNoWait(contractAddress, toAddress string, tokenId *big.Int, gasLimit *uint64) (common.Hash, error)
+
+	/*
+		grant or revoke an operator's approval to manage all of the caller's NFTs
+			- wait for mined
+			- gas limit is 300000 for default
+			- stops waiting when ctx is canceled
+	*/
+	SetApprovalForAll(ctx context.Context, contractAddress, operator string, approved bool, gasLimit *uint64) (*gethTypes.Receipt, error)
+
+	/*
+		grant or revoke an operator's approval to manage all of the caller's NFTs
+			- gas limit is 300000 for default
+	*/
+	SetApprovalForAllNoWait(contractAddress, operator string, approved bool, gasLimit *uint64) (common.Hash, error)
+
+	/*
 		get owner of the NFT with the given tokenId
 	*/
 	OwnerOf(contractAddress string, tokenId *big.Int) (string, error)

--- a/wallet/nft.go
+++ b/wallet/nft.go
@@ -116,6 +116,42 @@ func (api *walletNft) SafeTransferFromWithDataNoWait(contractAddress, fromAddres
 	)
 }
 
+func (api *walletNft) Approve(ctx context.Context, contractAddress, toAddress string, tokenId *big.Int, gasLimit *uint64) (*gethTypes.Receipt, error) {
+	return api.waitMined(ctx, func() (common.Hash, error) {
+		return api.ApproveNoWait(contractAddress, toAddress, tokenId, gasLimit)
+	})
+}
+
+func (api *walletNft) ApproveNoWait(contractAddress, toAddress string, tokenId *big.Int, gasLimit *uint64) (common.Hash, error) {
+	if err := validateAddress(toAddress); err != nil {
+		return common.Hash{}, err
+	}
+	if err := validateUint256(tokenId); err != nil {
+		return common.Hash{}, err
+	}
+	// ERC721 approve(to, tokenId) shares the ERC20 approve selector.
+	return api.sendNftTx(contractAddress, gasLimit, constant.ApproveFnSignature,
+		encode.ABIAddress(toAddress),
+		encode.ABIUint256(tokenId),
+	)
+}
+
+func (api *walletNft) SetApprovalForAll(ctx context.Context, contractAddress, operator string, approved bool, gasLimit *uint64) (*gethTypes.Receipt, error) {
+	return api.waitMined(ctx, func() (common.Hash, error) {
+		return api.SetApprovalForAllNoWait(contractAddress, operator, approved, gasLimit)
+	})
+}
+
+func (api *walletNft) SetApprovalForAllNoWait(contractAddress, operator string, approved bool, gasLimit *uint64) (common.Hash, error) {
+	if err := validateAddress(operator); err != nil {
+		return common.Hash{}, err
+	}
+	return api.sendNftTx(contractAddress, gasLimit, constant.SetApprovalForAllFnSignature,
+		encode.ABIAddress(operator),
+		encode.ABIBool(approved),
+	)
+}
+
 func (api *walletNft) OwnerOf(contractAddress string, tokenId *big.Int) (string, error) {
 	nft := api.w.snapshotNft()
 	if nft == nil {

--- a/wallet/nft_test.go
+++ b/wallet/nft_test.go
@@ -610,3 +610,304 @@ func TestWallet_NftSafeTransferFromWithDataNoWait(t *testing.T) {
 		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
 	})
 }
+
+func TestWallet_NftApprove(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	toAddress := "0xAbcdef1234567890abcdef1234567890AbCdEf12"
+	tokenId := big.NewInt(1)
+	expectedHash := common.HexToHash("0x123")
+
+	t.Run("can approve", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return expectedHash, nil
+			},
+		)
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"WaitMined",
+			func(_ *ether.Ether, _ context.Context, _ common.Hash) (*gethTypes.Receipt, error) {
+				return &gethTypes.Receipt{}, nil
+			},
+		)
+
+		_, err := w.Nft().Approve(context.Background(), contractAddress, toAddress, tokenId, nil)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("handle error on approve", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return common.Hash{}, errors.New("error")
+			},
+		)
+
+		_, err := w.Nft().Approve(context.Background(), contractAddress, toAddress, tokenId, nil)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.Nft().Approve(context.Background(), contractAddress, toAddress, tokenId, nil)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}
+
+func TestWallet_NftApproveNoWait(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	toAddress := "0xAbcdef1234567890abcdef1234567890AbCdEf12"
+	tokenId := big.NewInt(1)
+	expectedHash := common.HexToHash("0x123")
+
+	t.Run("can approve no wait & encodes approve calldata", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		var captured types.TransactionRequest
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, req types.TransactionRequest) (common.Hash, error) {
+				captured = req
+				return expectedHash, nil
+			},
+		)
+
+		txHash, err := w.Nft().ApproveNoWait(contractAddress, toAddress, tokenId, nil)
+
+		assert.Nil(t, err)
+		assert.Equal(t, expectedHash, txHash)
+
+		expectedData := encode.ReadCalldata(
+			constant.ApproveFnSignature,
+			encode.ABIAddress(toAddress),
+			encode.ABIUint256(tokenId),
+		)
+		assert.Equal(t, expectedData, captured.Data)
+		assert.Equal(t, contractAddress, captured.To)
+		assert.Equal(t, uint64(300000), captured.GasLimit)
+	})
+
+	t.Run("can approve no wait w/ custom gasLimit", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		var captured types.TransactionRequest
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, req types.TransactionRequest) (common.Hash, error) {
+				captured = req
+				return expectedHash, nil
+			},
+		)
+
+		gasLimit := uint64(500000)
+		_, err := w.Nft().ApproveNoWait(contractAddress, toAddress, tokenId, &gasLimit)
+
+		assert.Nil(t, err)
+		assert.Equal(t, uint64(500000), captured.GasLimit)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.Nft().ApproveNoWait(contractAddress, toAddress, tokenId, nil)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+
+	t.Run("invalid to-address returns ErrInvalidAddress", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.Nft().ApproveNoWait(contractAddress, "invalid", tokenId, nil)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
+
+	t.Run("nil tokenId returns ErrNilAmount", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.Nft().ApproveNoWait(contractAddress, toAddress, nil, nil)
+
+		assert.ErrorIs(t, err, constant.ErrNilAmount)
+	})
+
+	t.Run("invalid contractAddress returns ErrInvalidAddress", func(t *testing.T) {
+		w := createConnectedWallet()
+
+		_, err := w.Nft().ApproveNoWait("invalid", toAddress, tokenId, nil)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
+}
+
+func TestWallet_NftSetApprovalForAll(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	operatorAddress := "0xAbcdef1234567890abcdef1234567890AbCdEf12"
+	expectedHash := common.HexToHash("0x123")
+
+	t.Run("can set approval for all", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return expectedHash, nil
+			},
+		)
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"WaitMined",
+			func(_ *ether.Ether, _ context.Context, _ common.Hash) (*gethTypes.Receipt, error) {
+				return &gethTypes.Receipt{}, nil
+			},
+		)
+
+		_, err := w.Nft().SetApprovalForAll(context.Background(), contractAddress, operatorAddress, true, nil)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("handle error on set approval for all", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, _ types.TransactionRequest) (common.Hash, error) {
+				return common.Hash{}, errors.New("error")
+			},
+		)
+
+		_, err := w.Nft().SetApprovalForAll(context.Background(), contractAddress, operatorAddress, true, nil)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.Nft().SetApprovalForAll(context.Background(), contractAddress, operatorAddress, true, nil)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+}
+
+func TestWallet_NftSetApprovalForAllNoWait(t *testing.T) {
+	contractAddress := "0x1234567890123456789012345678901234567890"
+	operatorAddress := "0xAbcdef1234567890abcdef1234567890AbCdEf12"
+	expectedHash := common.HexToHash("0x123")
+
+	t.Run("encodes setApprovalForAll calldata (approved=true)", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		var captured types.TransactionRequest
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, req types.TransactionRequest) (common.Hash, error) {
+				captured = req
+				return expectedHash, nil
+			},
+		)
+
+		txHash, err := w.Nft().SetApprovalForAllNoWait(contractAddress, operatorAddress, true, nil)
+
+		assert.Nil(t, err)
+		assert.Equal(t, expectedHash, txHash)
+
+		expectedData := encode.ReadCalldata(
+			constant.SetApprovalForAllFnSignature,
+			encode.ABIAddress(operatorAddress),
+			encode.ABIBool(true),
+		)
+		assert.Equal(t, expectedData, captured.Data)
+		assert.Equal(t, contractAddress, captured.To)
+		assert.Equal(t, uint64(300000), captured.GasLimit)
+	})
+
+	t.Run("encodes setApprovalForAll calldata (approved=false)", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		w := createConnectedWallet()
+
+		var captured types.TransactionRequest
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"SendTransaction",
+			func(_ *wallet, req types.TransactionRequest) (common.Hash, error) {
+				captured = req
+				return expectedHash, nil
+			},
+		)
+
+		_, err := w.Nft().SetApprovalForAllNoWait(contractAddress, operatorAddress, false, nil)
+
+		assert.Nil(t, err)
+
+		expectedData := encode.ReadCalldata(
+			constant.SetApprovalForAllFnSignature,
+			encode.ABIAddress(operatorAddress),
+			encode.ABIBool(false),
+		)
+		assert.Equal(t, expectedData, captured.Data)
+	})
+
+	t.Run("error w/o connect wallet", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.Nft().SetApprovalForAllNoWait(contractAddress, operatorAddress, true, nil)
+
+		assert.ErrorIs(t, err, constant.ErrWalletIsNotConnected)
+	})
+
+	t.Run("invalid operator returns ErrInvalidAddress", func(t *testing.T) {
+		w, _ := New(testPrivHex)
+
+		_, err := w.Nft().SetApprovalForAllNoWait(contractAddress, "invalid", true, nil)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
+
+	t.Run("invalid contractAddress returns ErrInvalidAddress", func(t *testing.T) {
+		w := createConnectedWallet()
+
+		_, err := w.Nft().SetApprovalForAllNoWait("invalid", operatorAddress, true, nil)
+
+		assert.ErrorIs(t, err, constant.ErrInvalidAddress)
+	})
+}


### PR DESCRIPTION
## Summary

Adds ERC721 approval write methods to the wallet `Nft` namespace, closing #425 (part of #421, follows #424/#441).

- `Wallet.Nft.Approve(ctx, contractAddress, toAddress, tokenId, gasLimit)` / `ApproveNoWait(...)`
- `Wallet.Nft.SetApprovalForAll(ctx, contractAddress, operator, approved, gasLimit)` / `SetApprovalForAllNoWait(...)`

Each follows the established `wallet/nft.go` transfer pattern: `validate -> sendNftTx -> waitMined`, with a `NoWait` variant returning the tx hash and an optional trailing `gasLimit *uint64` (defaults to `300000`).

## Details

- Reuses the existing `ApproveFnSignature` (`approve(address,uint256)`) for ERC721 approve — same 4-byte selector as ERC20.
- Adds `SetApprovalForAllFnSignature` constant and an `encode.ABIBool` helper for the `bool` argument.
- Validates addresses and `tokenId` before encoding (#383, #398).

## Testing

- Unit tests assert the encoded calldata for both methods (#384), plus connection/validation error paths, and cover `encode.ABIBool`.
- e2e (`TestSimulated_Nft`): approve via the wallet then read back `GetApproved`; grant + revoke `SetApprovalForAll` and assert `IsApprovedForAll`.
- Docs updated (`docs/docs/wallet/Nft.md`).

All unit + simulated e2e tests pass. Reviewed via `/simplify` (reuse / simplification / efficiency / altitude) — no issues beyond a cosmetic comment placement.

refs: #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)