### PR TITLE
feat: famous NFT collection registry (#427)

### DIFF
--- a/docs/docs/famous/NftContractAddress.md
+++ b/docs/docs/famous/NftContractAddress.md
@@ -1,0 +1,99 @@
+---
+sidebar_position: 2
+---
+
+# Famous NFT
+
+`famous` also provides contract addresses for well-known NFT collections across supported networks.
+
+## NftSymbol
+
+Typed constant for well-known NFT collection symbols. Using these constants instead of raw strings prevents typos at compile time.
+
+```go
+type NftSymbol string
+
+const (
+    BAYC          NftSymbol = "BAYC"          // Bored Ape Yacht Club
+    MAYC          NftSymbol = "MAYC"          // Mutant Ape Yacht Club
+    CryptoPunks   NftSymbol = "CryptoPunks"   // CryptoPunks
+    Azuki         NftSymbol = "Azuki"         // Azuki
+    Doodles       NftSymbol = "Doodles"       // Doodles
+    PudgyPenguins NftSymbol = "PudgyPenguins" // Pudgy Penguins
+)
+```
+
+## NftContractAddress
+
+Returns the contract address of a well-known NFT collection on the given network.
+
+```go
+func NftContractAddress(network types.Network, symbol NftSymbol) (common.Address, error)
+```
+
+### Supported Collections
+
+| Symbol        | Networks   |
+|---------------|------------|
+| BAYC          | EthMainnet |
+| MAYC          | EthMainnet |
+| CryptoPunks   | EthMainnet |
+| Azuki         | EthMainnet |
+| Doodles       | EthMainnet |
+| PudgyPenguins | EthMainnet |
+
+### Errors
+
+- `famous.ErrNotSupportedNftNetwork` — the network has no registered NFT collection addresses
+- `famous.ErrNotSupportedNftSymbol` — the symbol is not registered for the given network
+
+### Example
+
+```go
+import (
+    "github.com/poteto-go/go-alchemy-sdk/famous"
+    "github.com/poteto-go/go-alchemy-sdk/types"
+)
+
+func main() {
+    addr, err := famous.NftContractAddress(types.EthMainnet, famous.BAYC)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(addr.Hex())
+}
+```
+
+## NftSupportedNetworks
+
+Returns all networks that have at least one registered NFT collection address.
+
+```go
+func NftSupportedNetworks() []types.Network
+```
+
+### Example
+
+```go
+networks := famous.NftSupportedNetworks()
+for _, n := range networks {
+    fmt.Println(n)
+}
+```
+
+## NftSupportedSymbols
+
+Returns all NFT collection symbols registered for the given network. Returns an empty slice if the network is not supported.
+
+```go
+func NftSupportedSymbols(network types.Network) []NftSymbol
+```
+
+### Example
+
+```go
+symbols := famous.NftSupportedSymbols(types.EthMainnet)
+for _, s := range symbols {
+    fmt.Println(s)
+}
+```

--- a/e2e/rpc_test.go
+++ b/e2e/rpc_test.go
@@ -291,6 +291,36 @@ func TestScenario_Famous_StableCoin(t *testing.T) {
 	})
 }
 
+func TestScenario_Famous_Nft(t *testing.T) {
+	t.Run("NftSupportedNetworks returns non-empty list including EthMainnet", func(t *testing.T) {
+		networks := famous.NftSupportedNetworks()
+
+		assert.NotEmpty(t, networks)
+		assert.True(t, slices.Contains(networks, types.EthMainnet))
+	})
+
+	t.Run("NftSupportedSymbols returns famous collections for EthMainnet", func(t *testing.T) {
+		symbols := famous.NftSupportedSymbols(types.EthMainnet)
+
+		assert.True(t, slices.Contains(symbols, famous.BAYC))
+		assert.True(t, slices.Contains(symbols, famous.CryptoPunks))
+		assert.True(t, slices.Contains(symbols, famous.Azuki))
+	})
+
+	t.Run("NftSupportedSymbols returns empty for unsupported network", func(t *testing.T) {
+		symbols := famous.NftSupportedSymbols(types.SolanaMainnet)
+
+		assert.Empty(t, symbols)
+	})
+
+	t.Run("NftContractAddress resolves typed symbol on EthMainnet", func(t *testing.T) {
+		addr, err := famous.NftContractAddress(types.EthMainnet, famous.BAYC)
+
+		assert.NoError(t, err)
+		assert.Equal(t, common.HexToAddress("0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D"), addr)
+	})
+}
+
 func TestScenario_StableCoin(t *testing.T) {
 	t.Run("1. can create wallet 2. connect wallet 3. can deploy erc20 contract as stablecoin", func(t *testing.T) {
 		w, err := wallet.New(initPrivateKey)

--- a/famous/nft.go
+++ b/famous/nft.go
@@ -1,0 +1,83 @@
+package famous
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/poteto-go/go-alchemy-sdk/types"
+)
+
+var (
+	ErrNotSupportedNftNetwork = errors.New("not supported network for this nft collection")
+	ErrNotSupportedNftSymbol  = errors.New("not supported nft collection symbol")
+)
+
+// NftSymbol is a typed constant for well-known NFT collection symbols.
+type NftSymbol string
+
+const (
+	BAYC          NftSymbol = "BAYC"          // Bored Ape Yacht Club
+	MAYC          NftSymbol = "MAYC"          // Mutant Ape Yacht Club
+	CryptoPunks   NftSymbol = "CryptoPunks"   // CryptoPunks
+	Azuki         NftSymbol = "Azuki"         // Azuki
+	Doodles       NftSymbol = "Doodles"       // Doodles
+	PudgyPenguins NftSymbol = "PudgyPenguins" // Pudgy Penguins
+)
+
+// nftAddresses maps network → collection symbol → contract address.
+// Addresses are pre-parsed at init time to avoid repeated hex conversion on each lookup.
+var nftAddresses = map[types.Network]map[NftSymbol]common.Address{
+	types.EthMainnet: {
+		// https://etherscan.io/address/0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d
+		BAYC: common.HexToAddress("0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D"),
+		// https://etherscan.io/address/0x60e4d786628fea6478f785a6d7e704777c86a7c6
+		MAYC: common.HexToAddress("0x60E4d786628Fea6478F785A6d7e704777c86a7c6"),
+		// https://etherscan.io/address/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb
+		CryptoPunks: common.HexToAddress("0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB"),
+		// https://etherscan.io/address/0xed5af388653567af2f388e6224dc7c4b3241c544
+		Azuki: common.HexToAddress("0xED5AF388653567Af2F388E6224dC7C4b3241C544"),
+		// https://etherscan.io/address/0x8a90cab2b38dba80c64b7734e58ee1db38b8992e
+		Doodles: common.HexToAddress("0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e"),
+		// https://etherscan.io/address/0xbd3531da5cf5857e7cfaa92426877b022e612cf8
+		PudgyPenguins: common.HexToAddress("0xBd3531dA5CF5857e7CfAA92426877b022e612cf8"),
+	},
+}
+
+// NftContractAddress returns the contract address of a well-known NFT collection on the given network.
+func NftContractAddress(network types.Network, symbol NftSymbol) (common.Address, error) {
+	networkMap, ok := nftAddresses[network]
+	if !ok {
+		return common.Address{}, ErrNotSupportedNftNetwork
+	}
+
+	addr, ok := networkMap[symbol]
+	if !ok {
+		return common.Address{}, ErrNotSupportedNftSymbol
+	}
+
+	return addr, nil
+}
+
+// NftSupportedNetworks returns all networks that have at least one registered NFT collection address.
+func NftSupportedNetworks() []types.Network {
+	networks := make([]types.Network, 0, len(nftAddresses))
+	for n := range nftAddresses {
+		networks = append(networks, n)
+	}
+	return networks
+}
+
+// NftSupportedSymbols returns all NFT collection symbols registered for the given network.
+// Returns an empty slice if the network is not supported.
+func NftSupportedSymbols(network types.Network) []NftSymbol {
+	networkMap, ok := nftAddresses[network]
+	if !ok {
+		return nil
+	}
+
+	symbols := make([]NftSymbol, 0, len(networkMap))
+	for s := range networkMap {
+		symbols = append(symbols, s)
+	}
+	return symbols
+}

--- a/famous/nft_test.go
+++ b/famous/nft_test.go
@@ -1,0 +1,102 @@
+package famous_test
+
+import (
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/poteto-go/go-alchemy-sdk/famous"
+	"github.com/poteto-go/go-alchemy-sdk/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNftContractAddress(t *testing.T) {
+	t.Run("returns known addresses using typed symbols", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			network types.Network
+			symbol  famous.NftSymbol
+			want    common.Address
+		}{
+			{
+				"BAYC on Ethereum mainnet",
+				types.EthMainnet, famous.BAYC,
+				common.HexToAddress("0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D"),
+			},
+			{
+				"MAYC on Ethereum mainnet",
+				types.EthMainnet, famous.MAYC,
+				common.HexToAddress("0x60E4d786628Fea6478F785A6d7e704777c86a7c6"),
+			},
+			{
+				"CryptoPunks on Ethereum mainnet",
+				types.EthMainnet, famous.CryptoPunks,
+				common.HexToAddress("0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB"),
+			},
+			{
+				"Azuki on Ethereum mainnet",
+				types.EthMainnet, famous.Azuki,
+				common.HexToAddress("0xED5AF388653567Af2F388E6224dC7C4b3241C544"),
+			},
+			{
+				"Doodles on Ethereum mainnet",
+				types.EthMainnet, famous.Doodles,
+				common.HexToAddress("0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e"),
+			},
+			{
+				"PudgyPenguins on Ethereum mainnet",
+				types.EthMainnet, famous.PudgyPenguins,
+				common.HexToAddress("0xBd3531dA5CF5857e7CfAA92426877b022e612cf8"),
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				addr, err := famous.NftContractAddress(tt.network, tt.symbol)
+
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, addr)
+			})
+		}
+	})
+
+	t.Run("returns error for unsupported network", func(t *testing.T) {
+		_, err := famous.NftContractAddress(types.SolanaMainnet, famous.BAYC)
+
+		assert.ErrorIs(t, err, famous.ErrNotSupportedNftNetwork)
+	})
+
+	t.Run("returns error for unsupported symbol", func(t *testing.T) {
+		_, err := famous.NftContractAddress(types.EthMainnet, "UNKNOWN")
+
+		assert.ErrorIs(t, err, famous.ErrNotSupportedNftSymbol)
+	})
+}
+
+func TestNftSupportedNetworks(t *testing.T) {
+	networks := famous.NftSupportedNetworks()
+
+	assert.NotEmpty(t, networks)
+	assert.True(t, slices.Contains(networks, types.EthMainnet))
+}
+
+func TestNftSupportedSymbols(t *testing.T) {
+	t.Run("returns symbols for EthMainnet", func(t *testing.T) {
+		symbols := famous.NftSupportedSymbols(types.EthMainnet)
+
+		got := make([]string, len(symbols))
+		for i, s := range symbols {
+			got[i] = string(s)
+		}
+		sort.Strings(got)
+
+		assert.Equal(t, []string{"Azuki", "BAYC", "CryptoPunks", "Doodles", "MAYC", "PudgyPenguins"}, got)
+	})
+
+	t.Run("returns empty slice for unsupported network", func(t *testing.T) {
+		symbols := famous.NftSupportedSymbols(types.SolanaMainnet)
+
+		assert.Empty(t, symbols)
+	})
+}


### PR DESCRIPTION
## Summary

Implements #427 — a famous NFT collection registry, mirroring the existing famous stablecoin registry shape.

### `famous/nft.go` (new public API)
- `NftSymbol` typed constants: `BAYC`, `MAYC`, `CryptoPunks`, `Azuki`, `Doodles`, `PudgyPenguins`
- `famous.NftContractAddress(network, symbol) (common.Address, error)` — same shape as `famous.ContractAddress`
- `NftSupportedNetworks()` / `NftSupportedSymbols(network)` listing helpers
- `ErrNotSupportedNftNetwork` / `ErrNotSupportedNftSymbol` (named distinctly since the non-`Nft` variants already exist for stablecoins in this package)
- Addresses pre-parsed into a `network → symbol → address` map (EthMainnet), each with its Etherscan link

### Docs & e2e (per project rule)
- `docs/docs/famous/NftContractAddress.md`
- `TestScenario_Famous_Nft` in `e2e/rpc_test.go`

## Testing
- Built via TDD (failing test first, then implementation)
- `go test ./famous/` — all pass
- `go vet ./e2e/` — clean

## Notes
Scope is limited to Ethereum-mainnet collections with verifiable contract addresses rather than guessing multi-chain deployments. The map is network-keyed, so adding more networks later is a data-only change.

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)