### PR TITLE
fix: validate ABI offset word & balanceOfBatch result count (#448)

### DIFF
--- a/constant/errors.go
+++ b/constant/errors.go
@@ -55,6 +55,7 @@ var (
 	ErrUnexpectedNilSimulatedBackend    = errors.New("unexpected nil of simulated backend")
 	ErrMismatchedArrayLength            = errors.New("array arguments must have the same length")
 	ErrInvalidABIArray                  = errors.New("invalid ABI array")
+	ErrUnexpectedBalanceCount           = errors.New("unexpected number of balances returned")
 )
 
 var HttpClientErrorCodeList = []int{

--- a/decode/abi.go
+++ b/decode/abi.go
@@ -15,8 +15,9 @@ func Uint256(output []byte) (*big.Int, error) {
 }
 
 // Uint256Array decodes an ABI-encoded dynamic uint256[] return value
-// (offset, length, items). The leading offset word points at the length field
-// and is assumed to be the standard 0x20 for a single dynamic return.
+// (offset, length, items). validate.ABIUint256Array checks that the leading
+// offset word is the standard 0x20 for a single dynamic return, so the length
+// field is read from the expected position.
 func Uint256Array(output []byte) ([]*big.Int, error) {
 	if err := validate.ABIUint256Array(output); err != nil {
 		return nil, err

--- a/decode/abi_test.go
+++ b/decode/abi_test.go
@@ -178,4 +178,11 @@ func TestUint256Array(t *testing.T) {
 		_, err := decode.Uint256Array(in)
 		assert.Error(t, err)
 	})
+
+	t.Run("non-standard offset word -> error", func(t *testing.T) {
+		// offset=0x40 instead of the standard 0x20.
+		in := append(append(make([]byte, 31), 0x40), make([]byte, 32)...)
+		_, err := decode.Uint256Array(in)
+		assert.Error(t, err)
+	})
 }

--- a/namespace/erc1155_namespace.go
+++ b/namespace/erc1155_namespace.go
@@ -86,7 +86,14 @@ func (e *Erc1155) BalanceOfBatch(contractAddress string, accounts []string, toke
 		return nil, err
 	}
 
-	return decode.Uint256Array(output)
+	balances, err := decode.Uint256Array(output)
+	if err != nil {
+		return nil, err
+	}
+	if len(balances) != len(accounts) {
+		return nil, constant.ErrUnexpectedBalanceCount
+	}
+	return balances, nil
 }
 
 func (e *Erc1155) Uri(contractAddress string, tokenId *big.Int) (string, error) {

--- a/namespace/erc1155_namespace_test.go
+++ b/namespace/erc1155_namespace_test.go
@@ -130,6 +130,25 @@ func TestErc1155_BalanceOfBatch(t *testing.T) {
 		assert.Equal(t, "20", balances[1].String())
 	})
 
+	t.Run("returns error if returned balance count differs from requested", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		eth := newEtherApi()
+		erc1155 := namespace.NewErc1155Namespace(eth)
+
+		patches.ApplyMethod(reflect.TypeOf(eth), "CallContract", func(_ *ether.Ether, _ ethereum.CallMsg, _ string) ([]byte, error) {
+			// requests 2 balances but the response only carries 1 element.
+			out := encode.ABIUint256(big.NewInt(constant.ABIWordSize))
+			out = append(out, encode.ABIUint256Array([]*big.Int{big.NewInt(10)})...)
+			return out, nil
+		})
+
+		_, err := erc1155.BalanceOfBatch(contractAddress, accounts, tokenIds)
+
+		assert.ErrorIs(t, err, constant.ErrUnexpectedBalanceCount)
+	})
+
 	t.Run("returns error if contract call fails", func(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -75,12 +75,12 @@ func declaredLengthExceedsAvailable(declared *big.Int, available int) bool {
 	return declared.Cmp(big.NewInt(int64(available))) > 0
 }
 
-// abiOffsetIsStandard reports whether the leading 32-byte word equals the
+// ABIOffsetIsStandard reports whether the leading 32-byte word equals the
 // standard 0x20 offset used for a single dynamic return value. An offset word
 // pointing elsewhere signals a malformed/malicious response that would read
 // the length from the wrong position. The standard offset is 31 zero bytes
 // followed by 0x20 (== constant.ABIWordSize).
-func abiOffsetIsStandard(output []byte) bool {
+func ABIOffsetIsStandard(output []byte) bool {
 	word := output[:constant.ABIWordSize]
 	for _, b := range word[:constant.ABIWordSize-1] {
 		if b != 0 {
@@ -97,7 +97,7 @@ func ABIUint256Array(output []byte) error {
 	if len(output) < constant.ABIWordSize*2 {
 		return constant.ErrInvalidABIArray
 	}
-	if !abiOffsetIsStandard(output) {
+	if !ABIOffsetIsStandard(output) {
 		return constant.ErrInvalidABIArray
 	}
 	dataStart := constant.ABIWordSize * 2
@@ -115,7 +115,7 @@ func ABIString(output []byte) error {
 	if len(output) < constant.ABIStringHeaderSize {
 		return constant.ErrInvalidABIString
 	}
-	if !abiOffsetIsStandard(output) {
+	if !ABIOffsetIsStandard(output) {
 		return constant.ErrInvalidABIString
 	}
 	length := new(big.Int).SetBytes(output[constant.ABIWordSize : constant.ABIWordSize*2])

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -75,11 +75,29 @@ func declaredLengthExceedsAvailable(declared *big.Int, available int) bool {
 	return declared.Cmp(big.NewInt(int64(available))) > 0
 }
 
+// abiOffsetIsStandard reports whether the leading 32-byte word equals the
+// standard 0x20 offset used for a single dynamic return value. An offset word
+// pointing elsewhere signals a malformed/malicious response that would read
+// the length from the wrong position. The standard offset is 31 zero bytes
+// followed by 0x20 (== constant.ABIWordSize).
+func abiOffsetIsStandard(output []byte) bool {
+	word := output[:constant.ABIWordSize]
+	for _, b := range word[:constant.ABIWordSize-1] {
+		if b != 0 {
+			return false
+		}
+	}
+	return word[constant.ABIWordSize-1] == constant.ABIWordSize
+}
+
 // ABIUint256Array validates an ABI-encoded uint256[] return value
 // (offset word + length word + element words) against the available output,
 // guarding callers against a slice out-of-range panic.
 func ABIUint256Array(output []byte) error {
 	if len(output) < constant.ABIWordSize*2 {
+		return constant.ErrInvalidABIArray
+	}
+	if !abiOffsetIsStandard(output) {
 		return constant.ErrInvalidABIArray
 	}
 	dataStart := constant.ABIWordSize * 2
@@ -95,6 +113,9 @@ func ABIUint256Array(output []byte) error {
 // out-of-range panic on malicious/corrupt contract or RPC data.
 func ABIString(output []byte) error {
 	if len(output) < constant.ABIStringHeaderSize {
+		return constant.ErrInvalidABIString
+	}
+	if !abiOffsetIsStandard(output) {
 		return constant.ErrInvalidABIString
 	}
 	length := new(big.Int).SetBytes(output[constant.ABIWordSize : constant.ABIWordSize*2])

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -130,12 +130,14 @@ func TestUrl(t *testing.T) {
 func TestABIUint256Array(t *testing.T) {
 	t.Run("valid: empty array", func(t *testing.T) {
 		out := make([]byte, constant.ABIWordSize*2)
+		out[constant.ABIWordSize-1] = 0x20 // standard offset
 		assert.NoError(t, validate.ABIUint256Array(out))
 	})
 
 	t.Run("valid: length fits within output", func(t *testing.T) {
 		// offset(32) + length=2(32) + 2 item words(64) = 128 bytes
 		out := make([]byte, constant.ABIWordSize*4)
+		out[constant.ABIWordSize-1] = 0x20 // standard offset
 		out[constant.ABIWordSize*2-1] = 2
 		assert.NoError(t, validate.ABIUint256Array(out))
 	})
@@ -144,14 +146,22 @@ func TestABIUint256Array(t *testing.T) {
 		assert.ErrorIs(t, validate.ABIUint256Array(make([]byte, 31)), constant.ErrInvalidABIArray)
 	})
 
+	t.Run("non-standard offset word", func(t *testing.T) {
+		// offset=0x40 instead of the standard 0x20.
+		out := make([]byte, constant.ABIWordSize*2)
+		out[constant.ABIWordSize-1] = 0x40
+		assert.ErrorIs(t, validate.ABIUint256Array(out), constant.ErrInvalidABIArray)
+	})
+
 	t.Run("declared length exceeds output", func(t *testing.T) {
-		// offset + length=5 but no element words follow
-		out := append(make([]byte, constant.ABIWordSize), append(make([]byte, constant.ABIWordSize-1), 0x05)...)
+		// offset=0x20 + length=5 but no element words follow
+		out := append(append(make([]byte, constant.ABIWordSize-1), 0x20), append(make([]byte, constant.ABIWordSize-1), 0x05)...)
 		assert.ErrorIs(t, validate.ABIUint256Array(out), constant.ErrInvalidABIArray)
 	})
 
 	t.Run("malicious length does not panic", func(t *testing.T) {
 		out := make([]byte, constant.ABIWordSize*2)
+		out[constant.ABIWordSize-1] = 0x20 // standard offset
 		for i := constant.ABIWordSize; i < constant.ABIWordSize*2; i++ {
 			out[i] = 0xFF
 		}
@@ -165,6 +175,7 @@ func TestABIString(t *testing.T) {
 	t.Run("normal case: valid header and length", func(t *testing.T) {
 		// header declares length 3 with a full data word following.
 		output := make([]byte, constant.ABIStringHeaderSize+constant.ABIWordSize)
+		output[constant.ABIWordSize-1] = 0x20 // standard offset
 		output[constant.ABIStringHeaderSize-1] = 3
 
 		assert.NoError(t, validate.ABIString(output))
@@ -175,8 +186,17 @@ func TestABIString(t *testing.T) {
 			assert.ErrorIs(t, validate.ABIString([]byte("too-short")), constant.ErrInvalidABIString)
 		})
 
+		t.Run("non-standard offset word", func(t *testing.T) {
+			// offset=0x40 instead of the standard 0x20.
+			output := make([]byte, constant.ABIStringHeaderSize)
+			output[constant.ABIWordSize-1] = 0x40
+
+			assert.ErrorIs(t, validate.ABIString(output), constant.ErrInvalidABIString)
+		})
+
 		t.Run("declared length exceeds output", func(t *testing.T) {
 			output := make([]byte, constant.ABIStringHeaderSize)
+			output[constant.ABIWordSize-1] = 0x20 // standard offset
 			output[constant.ABIStringHeaderSize-1] = 100
 
 			assert.ErrorIs(t, validate.ABIString(output), constant.ErrInvalidABIString)
@@ -186,6 +206,7 @@ func TestABIString(t *testing.T) {
 			// lower 8 bytes of the length word set to 0xFF...FF, which would
 			// make Int64() negative and slip past a naive bounds check.
 			output := make([]byte, constant.ABIStringHeaderSize)
+			output[constant.ABIWordSize-1] = 0x20 // standard offset
 			for i := constant.ABIWordSize; i < constant.ABIStringHeaderSize; i++ {
 				output[i] = 0xFF
 			}

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -127,6 +127,28 @@ func TestUrl(t *testing.T) {
 	}
 }
 
+func TestABIOffsetIsStandard(t *testing.T) {
+	t.Run("standard 0x20 offset", func(t *testing.T) {
+		out := make([]byte, constant.ABIWordSize)
+		out[constant.ABIWordSize-1] = 0x20
+		assert.True(t, validate.ABIOffsetIsStandard(out))
+	})
+
+	t.Run("non-standard offset value", func(t *testing.T) {
+		out := make([]byte, constant.ABIWordSize)
+		out[constant.ABIWordSize-1] = 0x40
+		assert.False(t, validate.ABIOffsetIsStandard(out))
+	})
+
+	t.Run("non-zero high byte", func(t *testing.T) {
+		// a huge offset whose low byte happens to be 0x20 must not pass.
+		out := make([]byte, constant.ABIWordSize)
+		out[0] = 0x01
+		out[constant.ABIWordSize-1] = 0x20
+		assert.False(t, validate.ABIOffsetIsStandard(out))
+	})
+}
+
 func TestABIUint256Array(t *testing.T) {
 	t.Run("valid: empty array", func(t *testing.T) {
 		out := make([]byte, constant.ABIWordSize*2)


### PR DESCRIPTION
## Summary

Hardens decoding of untrusted RPC responses, addressing #448.

- **`validate.ABIUint256Array` / `validate.ABIString`** now read and validate the leading ABI offset word. Previously the length field was read from a fixed `0x20` position regardless of the actual offset word, so a malformed/malicious response with a non-standard offset would silently yield a wrong result. Both validators now reject responses whose offset word is not the standard `0x20`.
- **`Erc1155.BalanceOfBatch`** now returns the new `constant.ErrUnexpectedBalanceCount` when the decoded balance count differs from `len(accounts)`, so callers can't end up with a silently misaligned (account ↔ balance) index mapping.

A new `abiOffsetIsStandard` helper is shared by both validators.

## Why a dedicated error

`ErrUnexpectedBalanceCount` is intentionally distinct from `ErrMismatchedArrayLength`: the latter is a *caller input* error (accounts vs. tokenIds length), while the former flags an *untrusted RPC response* returning the wrong number of elements. Keeping them separate lets callers distinguish bad input from a malformed response.

## Testing

- Added validate/decode test cases for non-standard offset words.
- Added a `BalanceOfBatch` test asserting `ErrUnexpectedBalanceCount` when the response carries fewer elements than requested.
- `go build ./...`, `go vet`, and unit tests pass. (`/simplify` was run on the diff before opening this PR.)

refs #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)