### PR TITLE
fix: use eth_estimateGas as default when gasLimit is nil

### DIFF
--- a/wallet/erc1155_test.go
+++ b/wallet/erc1155_test.go
@@ -215,7 +215,7 @@ func TestWallet_ERC1155SafeTransferFromNoWait(t *testing.T) {
 		)
 		assert.Equal(t, expectedData, captured.Data)
 		assert.Equal(t, contractAddress, captured.To)
-		assert.Equal(t, uint64(300000), captured.GasLimit)
+		assert.Equal(t, uint64(0), captured.GasLimit)
 	})
 
 	t.Run("custom gasLimit is forwarded", func(t *testing.T) {
@@ -404,7 +404,7 @@ func TestWallet_ERC1155SafeBatchTransferFromNoWait(t *testing.T) {
 		expectedData := encode.ReadCalldata(constant.SafeBatchTransferFromFnSignature, args)
 		assert.Equal(t, expectedData, captured.Data)
 		assert.Equal(t, contractAddress, captured.To)
-		assert.Equal(t, uint64(300000), captured.GasLimit)
+		assert.Equal(t, uint64(0), captured.GasLimit)
 	})
 
 	t.Run("custom gasLimit is forwarded", func(t *testing.T) {

--- a/wallet/erc20.go
+++ b/wallet/erc20.go
@@ -35,7 +35,7 @@ func (api *walletERC20) Transfer(ctx context.Context, contractAddress, toAddress
 
 func resolveGasLimit(gasLimit *uint64) uint64 {
 	if gasLimit == nil {
-		return 300000
+		return 0 // 0 is the sentinel for "auto": SignTx fills it from eth_estimateGas
 	}
 	return *gasLimit
 }

--- a/wallet/nft_test.go
+++ b/wallet/nft_test.go
@@ -324,7 +324,7 @@ func TestWallet_NftTransferFromNoWait(t *testing.T) {
 		)
 		assert.Equal(t, expectedData, captured.Data)
 		assert.Equal(t, contractAddress, captured.To)
-		assert.Equal(t, uint64(300000), captured.GasLimit)
+		assert.Equal(t, uint64(0), captured.GasLimit)
 	})
 
 	t.Run("can transfer from no wait w/ custom gasLimit", func(t *testing.T) {
@@ -734,7 +734,7 @@ func TestWallet_NftApproveNoWait(t *testing.T) {
 		)
 		assert.Equal(t, expectedData, captured.Data)
 		assert.Equal(t, contractAddress, captured.To)
-		assert.Equal(t, uint64(300000), captured.GasLimit)
+		assert.Equal(t, uint64(0), captured.GasLimit)
 	})
 
 	t.Run("can approve no wait w/ custom gasLimit", func(t *testing.T) {
@@ -885,7 +885,7 @@ func TestWallet_NftSetApprovalForAllNoWait(t *testing.T) {
 		)
 		assert.Equal(t, expectedData, captured.Data)
 		assert.Equal(t, contractAddress, captured.To)
-		assert.Equal(t, uint64(300000), captured.GasLimit)
+		assert.Equal(t, uint64(0), captured.GasLimit)
 	})
 
 	t.Run("encodes setApprovalForAll calldata (approved=false)", func(t *testing.T) {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -150,7 +150,9 @@ func (w *wallet) SignTx(txRequest types.TransactionRequest) (*gethTypes.Transact
 	if err != nil {
 		return nil, err
 	}
-	if txRequest.GasLimit < estimatedGas.Uint64() {
+	if txRequest.GasLimit == 0 { // 0 = auto sentinel from resolveGasLimit(nil)
+		txRequest.GasLimit = estimatedGas.Uint64()
+	} else if txRequest.GasLimit < estimatedGas.Uint64() {
 		return nil, fmt.Errorf(
 			"gasLimit(%d) is less than estimated gas %d",
 			txRequest.GasLimit,

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -421,13 +421,65 @@ func TestWallet_SignTx(t *testing.T) {
 			},
 		)
 
-		// Act
+		// Act — explicit gasLimit smaller than estimate
 		_, err := w.SignTx(types.TransactionRequest{
-			GasLimit: 0,
+			GasLimit: 50,
 		})
 
 		// Assert
 		assert.Error(t, err)
+	})
+
+	t.Run("if gasLimit == 0, auto-apply estimatedGas", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		// Arrange
+		w := createConnectedWallet()
+
+		// Mock
+		patches.ApplyMethod(
+			reflect.TypeOf(w),
+			"PendingNonceAt",
+			func(_ *wallet) (uint64, error) {
+				return uint64(0), nil
+			},
+		)
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"EstimateGas",
+			func(_ *ether.Ether, _ types.TransactionRequest) (*big.Int, error) {
+				return big.NewInt(100), nil
+			},
+		)
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"SuggestGasPrice",
+			func(_ *ether.Ether) (*big.Int, error) {
+				return big.NewInt(1_000_000_000), nil
+			},
+		)
+
+		patches.ApplyMethod(
+			reflect.TypeOf(w.provider.Eth()),
+			"ChainID",
+			func(_ *ether.Ether) (*big.Int, error) {
+				return big.NewInt(1), nil
+			},
+		)
+
+		// Act — GasLimit=0 means "auto"
+		signedTx, err := w.SignTx(types.TransactionRequest{
+			GasLimit: 0,
+			To:       "0x" + testAddrHexTo,
+			Value:    "0x0",
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(100), signedTx.Gas())
 	})
 
 	t.Run("if error occur on transform, return error", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `resolveGasLimit(nil)` now returns `0` as a sentinel (was `300000`)
- `SignTx` detects the `0` sentinel and sets `GasLimit` from `eth_estimateGas`, so ERC-1155 batch transfers with many token IDs or contract receivers get a gas budget that matches the actual call cost
- When the caller supplies an explicit `gasLimit`, the existing safety check (`gasLimit < estimatedGas → error`) is unchanged

## Motivation

The hardcoded 300 000 default was insufficient for `SafeBatchTransferFrom` with more than ~10 token IDs (each `SSTORE` adds ~20 k gas), and for any transfer to a contract receiver whose `onERC1155Received`/`onERC1155BatchReceived` hook consumes non-trivial gas. The transaction would be submitted and then revert on-chain, wasting the gas. Fixes #447.

## Test plan

- [ ] `just ut` — all packages pass
- [ ] New `TestWallet_SignTx/if_gasLimit_==_0,_auto-apply_estimatedGas` confirms `signedTx.Gas()` equals the mocked `EstimateGas` return value
- [ ] Existing tests updated: nil-gasLimit assertions now check `GasLimit == 0` (the sentinel passed to `SendTransaction`), and the "too-small explicit limit" test uses `GasLimit: 50` instead of `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)