### PR TITLE
feat: add NftBatch and ERC1155Batch to Batcher (#455)

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -5,8 +5,10 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/poteto-go/go-alchemy-sdk/constant"
+	"github.com/poteto-go/go-alchemy-sdk/decode"
 	"github.com/poteto-go/go-alchemy-sdk/encode"
 	"github.com/poteto-go/go-alchemy-sdk/types"
+	"github.com/poteto-go/go-alchemy-sdk/validate"
 )
 
 /*
@@ -74,6 +76,8 @@ type Batcher struct {
 	Core       *CoreBatch
 	ERC20      *ERC20Batch
 	StableCoin *StableCoinBatch
+	Nft        *NftBatch
+	ERC1155    *ERC1155Batch
 }
 
 // NewBatcher creates a Batcher bound to the given EtherApi (e.g.
@@ -83,6 +87,8 @@ func NewBatcher(ether types.EtherApi) *Batcher {
 	b.Core = &CoreBatch{b: b}
 	b.ERC20 = &ERC20Batch{b: b}
 	b.StableCoin = &StableCoinBatch{ERC20Batch: b.ERC20}
+	b.Nft = &NftBatch{b: b}
+	b.ERC1155 = &ERC1155Batch{b: b}
 	return b
 }
 
@@ -185,4 +191,13 @@ func AddCall[T any](
 
 	return addConv(b, constant.Eth_Call, []any{call, "latest"}, target,
 		func(t *hexutil.Bytes) (T, error) { return decode([]byte(*t)) })
+}
+
+// addStringCall validates a single contract address and queues an eth_call
+// that decodes its result as an ABI string. Used by ERC20Batch and NftBatch.
+func addStringCall(b *Batcher, contractAddress string, fnSig []byte) *Result[string] {
+	if err := validate.Address(contractAddress); err != nil {
+		return failed[string](err)
+	}
+	return AddCall(b, contractAddress, fnSig, decode.ABIString)
 }

--- a/batch/erc1155.go
+++ b/batch/erc1155.go
@@ -1,0 +1,37 @@
+package batch
+
+import (
+	"math/big"
+
+	"github.com/poteto-go/go-alchemy-sdk/constant"
+	"github.com/poteto-go/go-alchemy-sdk/decode"
+	"github.com/poteto-go/go-alchemy-sdk/encode"
+	"github.com/poteto-go/go-alchemy-sdk/validate"
+)
+
+// ERC1155Batch queues ERC-1155 contract reads onto its Batcher. Mirrors the
+// read-only methods of the Erc1155 namespace and validates the same inputs.
+type ERC1155Batch struct {
+	b *Batcher
+}
+
+func (e *ERC1155Batch) BalanceOfToken(contractAddress, account string, tokenId *big.Int) *Result[*big.Int] {
+	if err := validate.Addresses(contractAddress, account); err != nil {
+		return failed[*big.Int](err)
+	}
+	if err := validate.Uint256(tokenId); err != nil {
+		return failed[*big.Int](err)
+	}
+	return AddCall(e.b, contractAddress, constant.BalanceOfTokenFnSignature, decode.Uint256,
+		encode.ABIAddress(account), encode.ABIUint256(tokenId))
+}
+
+func (e *ERC1155Batch) Uri(contractAddress string, tokenId *big.Int) *Result[string] {
+	if err := validate.Address(contractAddress); err != nil {
+		return failed[string](err)
+	}
+	if err := validate.Uint256(tokenId); err != nil {
+		return failed[string](err)
+	}
+	return AddCall(e.b, contractAddress, constant.UriFnSignature, decode.ABIString, encode.ABIUint256(tokenId))
+}

--- a/batch/erc1155_test.go
+++ b/batch/erc1155_test.go
@@ -1,0 +1,52 @@
+package batch_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/poteto-go/go-alchemy-sdk/alchemymock"
+	"github.com/poteto-go/go-alchemy-sdk/batch"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestERC1155Batch_AllMethods(t *testing.T) {
+	mock := alchemymock.NewAlchemyHttpMock(batchSetting, t)
+	defer mock.DeactivateAndReset()
+
+	tokenId := big.NewInt(42)
+	b := batch.NewBatcher(newBatchEther())
+	balance := b.ERC1155.BalanceOfToken(contractAddr, walletAddr, tokenId)
+	uri := b.ERC1155.Uri(contractAddr, tokenId)
+
+	mock.RegisterBatchResponderOnce(resp(
+		uintWord(7),
+		abiStrWord("https://example.com/token/{id}"),
+	))
+
+	assert.NoError(t, b.Send())
+
+	assertUnwrapStr(t, balance, "7")
+	assertUnwrap(t, uri, "https://example.com/token/{id}")
+}
+
+func TestERC1155Batch_InvalidInputs(t *testing.T) {
+	b := batch.NewBatcher(newBatchEther())
+	bad := "not-an-address"
+	tokenId := big.NewInt(1)
+
+	cases := []struct {
+		name string
+		run  func() error
+	}{
+		{"BalanceOfToken bad contract", func() error { _, e := b.ERC1155.BalanceOfToken(bad, walletAddr, tokenId).Unwrap(); return e }},
+		{"BalanceOfToken bad account", func() error { _, e := b.ERC1155.BalanceOfToken(contractAddr, bad, tokenId).Unwrap(); return e }},
+		{"BalanceOfToken nil tokenId", func() error { _, e := b.ERC1155.BalanceOfToken(contractAddr, walletAddr, nil).Unwrap(); return e }},
+		{"Uri bad contract", func() error { _, e := b.ERC1155.Uri(bad, tokenId).Unwrap(); return e }},
+		{"Uri nil tokenId", func() error { _, e := b.ERC1155.Uri(contractAddr, nil).Unwrap(); return e }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Error(t, tc.run())
+		})
+	}
+}

--- a/batch/erc20.go
+++ b/batch/erc20.go
@@ -38,17 +38,11 @@ func (e *ERC20Batch) Allowance(contractAddress, owner, spender string) *Result[*
 }
 
 func (e *ERC20Batch) Name(contractAddress string) *Result[string] {
-	if err := validate.Address(contractAddress); err != nil {
-		return failed[string](err)
-	}
-	return AddCall(e.b, contractAddress, constant.NameFnSignature, decode.ABIString)
+	return addStringCall(e.b, contractAddress, constant.NameFnSignature)
 }
 
 func (e *ERC20Batch) Symbol(contractAddress string) *Result[string] {
-	if err := validate.Address(contractAddress); err != nil {
-		return failed[string](err)
-	}
-	return AddCall(e.b, contractAddress, constant.SymbolFnSignature, decode.ABIString)
+	return addStringCall(e.b, contractAddress, constant.SymbolFnSignature)
 }
 
 func (e *ERC20Batch) Decimals(contractAddress string) *Result[uint8] {

--- a/batch/nft.go
+++ b/batch/nft.go
@@ -1,0 +1,71 @@
+package batch
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/poteto-go/go-alchemy-sdk/constant"
+	"github.com/poteto-go/go-alchemy-sdk/decode"
+	"github.com/poteto-go/go-alchemy-sdk/encode"
+	"github.com/poteto-go/go-alchemy-sdk/validate"
+)
+
+// NftBatch queues ERC-721 contract reads onto its Batcher. Mirrors the
+// read-only methods of the Nft namespace and validates the same inputs.
+type NftBatch struct {
+	b *Batcher
+}
+
+// decodeAddressHex decodes an ABI address and returns it as a lowercase hex string.
+func decodeAddressHex(output []byte) (string, error) {
+	addr, err := decode.ABIAddress(output)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("0x%x", addr[:]), nil
+}
+
+// addAddressTokenCall validates address + tokenId, then queues an eth_call
+// that decodes its result as a lowercase hex address. Used by OwnerOf and GetApproved.
+func addAddressTokenCall(b *Batcher, fnSig []byte, contractAddress string, tokenId *big.Int) *Result[string] {
+	if err := validate.Address(contractAddress); err != nil {
+		return failed[string](err)
+	}
+	if err := validate.Uint256(tokenId); err != nil {
+		return failed[string](err)
+	}
+	return AddCall(b, contractAddress, fnSig, decodeAddressHex, encode.ABIUint256(tokenId))
+}
+
+func (n *NftBatch) BalanceOf(contractAddress, owner string) *Result[*big.Int] {
+	if err := validate.Addresses(contractAddress, owner); err != nil {
+		return failed[*big.Int](err)
+	}
+	return AddCall(n.b, contractAddress, constant.BalanceOfFnSignature, decode.Uint256, encode.ABIAddress(owner))
+}
+
+func (n *NftBatch) OwnerOf(contractAddress string, tokenId *big.Int) *Result[string] {
+	return addAddressTokenCall(n.b, constant.OwnerOfFnSignature, contractAddress, tokenId)
+}
+
+func (n *NftBatch) TokenURI(contractAddress string, tokenId *big.Int) *Result[string] {
+	if err := validate.Address(contractAddress); err != nil {
+		return failed[string](err)
+	}
+	if err := validate.Uint256(tokenId); err != nil {
+		return failed[string](err)
+	}
+	return AddCall(n.b, contractAddress, constant.TokenURIFnSignature, decode.ABIString, encode.ABIUint256(tokenId))
+}
+
+func (n *NftBatch) Name(contractAddress string) *Result[string] {
+	return addStringCall(n.b, contractAddress, constant.NameFnSignature)
+}
+
+func (n *NftBatch) Symbol(contractAddress string) *Result[string] {
+	return addStringCall(n.b, contractAddress, constant.SymbolFnSignature)
+}
+
+func (n *NftBatch) GetApproved(contractAddress string, tokenId *big.Int) *Result[string] {
+	return addAddressTokenCall(n.b, constant.GetApprovedFnSignature, contractAddress, tokenId)
+}

--- a/batch/nft_test.go
+++ b/batch/nft_test.go
@@ -43,6 +43,22 @@ func TestNftBatch_AllMethods(t *testing.T) {
 	assertUnwrap(t, getApproved, strings.ToLower(common.HexToAddress(spenderAddr).Hex()))
 }
 
+func TestNftBatch_DecodeError(t *testing.T) {
+	mock := alchemymock.NewAlchemyHttpMock(batchSetting, t)
+	defer mock.DeactivateAndReset()
+
+	b := batch.NewBatcher(newBatchEther())
+	ownerOf := b.Nft.OwnerOf(contractAddr, big.NewInt(1))
+
+	// Too-short response (2 bytes): decode.ABIAddress errors on < 32 bytes.
+	mock.RegisterBatchResponderOnce(resp("1234"))
+
+	assert.NoError(t, b.Send())
+
+	_, err := ownerOf.Unwrap()
+	assert.Error(t, err)
+}
+
 func TestNftBatch_InvalidInputs(t *testing.T) {
 	b := batch.NewBatcher(newBatchEther())
 	bad := "not-an-address"

--- a/batch/nft_test.go
+++ b/batch/nft_test.go
@@ -1,0 +1,71 @@
+package batch_test
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/poteto-go/go-alchemy-sdk/alchemymock"
+	"github.com/poteto-go/go-alchemy-sdk/batch"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNftBatch_AllMethods(t *testing.T) {
+	mock := alchemymock.NewAlchemyHttpMock(batchSetting, t)
+	defer mock.DeactivateAndReset()
+
+	tokenId := big.NewInt(1)
+	b := batch.NewBatcher(newBatchEther())
+	balance := b.Nft.BalanceOf(contractAddr, walletAddr)
+	ownerOf := b.Nft.OwnerOf(contractAddr, tokenId)
+	tokenURI := b.Nft.TokenURI(contractAddr, tokenId)
+	name := b.Nft.Name(contractAddr)
+	symbol := b.Nft.Symbol(contractAddr)
+	getApproved := b.Nft.GetApproved(contractAddr, tokenId)
+
+	mock.RegisterBatchResponderOnce(resp(
+		uintWord(5),
+		addrWord(ownerAddr),
+		abiStrWord("ipfs://token1"),
+		abiStrWord("CryptoKitties"),
+		abiStrWord("CK"),
+		addrWord(spenderAddr),
+	))
+
+	assert.NoError(t, b.Send())
+
+	assertUnwrapStr(t, balance, "5")
+	assertUnwrap(t, ownerOf, strings.ToLower(common.HexToAddress(ownerAddr).Hex()))
+	assertUnwrap(t, tokenURI, "ipfs://token1")
+	assertUnwrap(t, name, "CryptoKitties")
+	assertUnwrap(t, symbol, "CK")
+	assertUnwrap(t, getApproved, strings.ToLower(common.HexToAddress(spenderAddr).Hex()))
+}
+
+func TestNftBatch_InvalidInputs(t *testing.T) {
+	b := batch.NewBatcher(newBatchEther())
+	bad := "not-an-address"
+	tokenId := big.NewInt(1)
+
+	cases := []struct {
+		name string
+		run  func() error
+	}{
+		{"BalanceOf bad contract", func() error { _, e := b.Nft.BalanceOf(bad, walletAddr).Unwrap(); return e }},
+		{"BalanceOf bad wallet", func() error { _, e := b.Nft.BalanceOf(contractAddr, bad).Unwrap(); return e }},
+		{"OwnerOf bad contract", func() error { _, e := b.Nft.OwnerOf(bad, tokenId).Unwrap(); return e }},
+		{"OwnerOf nil tokenId", func() error { _, e := b.Nft.OwnerOf(contractAddr, nil).Unwrap(); return e }},
+		{"TokenURI bad contract", func() error { _, e := b.Nft.TokenURI(bad, tokenId).Unwrap(); return e }},
+		{"TokenURI nil tokenId", func() error { _, e := b.Nft.TokenURI(contractAddr, nil).Unwrap(); return e }},
+		{"Name bad contract", func() error { _, e := b.Nft.Name(bad).Unwrap(); return e }},
+		{"Symbol bad contract", func() error { _, e := b.Nft.Symbol(bad).Unwrap(); return e }},
+		{"GetApproved bad contract", func() error { _, e := b.Nft.GetApproved(bad, tokenId).Unwrap(); return e }},
+		{"GetApproved nil tokenId", func() error { _, e := b.Nft.GetApproved(contractAddr, nil).Unwrap(); return e }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Error(t, tc.run())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `NftBatch` to `Batcher` with `BalanceOf`, `OwnerOf`, `TokenURI`, `Name`, `Symbol`, `GetApproved` — mirrors the `Nft` namespace
- Adds `ERC1155Batch` to `Batcher` with `BalanceOfToken` and `Uri` — mirrors the `Erc1155` namespace
- Extracts `addStringCall` (shared by `ERC20Batch` and `NftBatch`) and `addAddressTokenCall` (used by `OwnerOf` and `GetApproved`) to eliminate duplication
- `OwnerOf` and `GetApproved` return `*Result[string]` (lowercase hex address, consistent with the `Nft` namespace)

## Test plan

- [ ] `TestNftBatch_AllMethods` — happy path for all 6 methods in a single batch round-trip
- [ ] `TestNftBatch_InvalidInputs` — address and tokenId validation rejects bad inputs pre-Send
- [ ] `TestERC1155Batch_AllMethods` — happy path for both methods
- [ ] `TestERC1155Batch_InvalidInputs` — validation coverage
- [ ] Existing `TestERC20Batch_*` tests still pass after `Name`/`Symbol` refactor

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)