### PR TITLE
feat: EIP-1559 fee market helpers (SuggestGasTipCap / SuggestEIP1559Fees)

### DIFF
--- a/constant/errors.go
+++ b/constant/errors.go
@@ -60,6 +60,7 @@ var (
 	ErrENSResolverNotFound              = errors.New("ENS resolver not found for name")
 	ErrENSNameNotFound                  = errors.New("ENS name not found for address")
 	ErrENSNotSupportedOnNetwork         = errors.New("ENS not available on this network")
+	ErrChainNotSupportEIP1559           = errors.New("chain does not support EIP-1559")
 )
 
 var HttpClientErrorCodeList = []int{

--- a/docs/docs/core-namespace/SuggestEIP1559Fees.md
+++ b/docs/docs/core-namespace/SuggestEIP1559Fees.md
@@ -1,0 +1,24 @@
+![](https://img.shields.io/badge/go-geth-lightblue)
+
+Returns `(maxPriorityFeePerGas, maxFeePerGas)` ready to use in a `TransactionRequest`.
+
+`maxFeePerGas` is derived as `baseFeePerGas * 2 + maxPriorityFeePerGas` (standard EIP-1559 formula).
+Returns an error on chains that do not support EIP-1559.
+
+```go
+func SuggestEIP1559Fees() (maxPriorityFeePerGas *big.Int, maxFeePerGas *big.Int, err error)
+```
+
+```go
+func main() {
+	...
+	alchemy := gas.NewAlchemy(setting)
+	tip, maxFee, _ := alchemy.Core.SuggestEIP1559Fees()
+
+	tx := types.TransactionRequest{
+		MaxPriorityFeePerGas: tip.String(),
+		MaxFeePerGas:         maxFee.String(),
+		// ...
+	}
+}
+```

--- a/docs/docs/core-namespace/SuggestGasTipCap.md
+++ b/docs/docs/core-namespace/SuggestGasTipCap.md
@@ -1,0 +1,15 @@
+![](https://img.shields.io/badge/go-geth-lightblue)
+
+Returns the suggested `maxPriorityFeePerGas` (EIP-1559 tip) via `eth_maxPriorityFeePerGas`.
+
+```go
+func SuggestGasTipCap() (tip *big.Int, err error)
+```
+
+```go
+func main() {
+	...
+	alchemy := gas.NewAlchemy(setting)
+	tip, _ := alchemy.Core.SuggestGasTipCap()
+}
+```

--- a/e2e/rpc_test.go
+++ b/e2e/rpc_test.go
@@ -70,6 +70,22 @@ func TestSenario_BaseMethod(t *testing.T) {
 		assert.Equal(t, gasPrice.Cmp(big.NewInt(0)), 1)
 	})
 
+	t.Run("SuggestGasTipCap", func(t *testing.T) {
+		tip, err := alchemy.Core.SuggestGasTipCap()
+
+		assert.Nil(t, err)
+		assert.NotNil(t, tip)
+	})
+
+	t.Run("SuggestEIP1559Fees", func(t *testing.T) {
+		tip, maxFee, err := alchemy.Core.SuggestEIP1559Fees()
+
+		assert.Nil(t, err)
+		assert.NotNil(t, tip)
+		assert.NotNil(t, maxFee)
+		assert.True(t, maxFee.Cmp(tip) >= 0)
+	})
+
 	t.Run("estimate gas", func(t *testing.T) {
 		gas, err := alchemy.Core.EstimateGas(types.TransactionRequest{
 			From:  initAddress,

--- a/ether/ether.go
+++ b/ether/ether.go
@@ -558,6 +558,58 @@ func (ether *Ether) SuggestGasPrice() (*big.Int, error) {
 	return res, nil
 }
 
+func (ether *Ether) SuggestGasTipCap() (*big.Int, error) {
+	if err := ether.SetEthClient(); err != nil {
+		return nil, err
+	}
+	defer ether.Close()
+
+	c := ether.Client()
+	tip, err := internal.GethRequestWithBackOff(
+		ether.config.backoffConfig,
+		ether.config.requestTimeout,
+		c.SuggestGasTipCap,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return tip, nil
+}
+
+func (ether *Ether) SuggestEIP1559Fees() (*big.Int, *big.Int, error) {
+	if err := ether.SetEthClient(); err != nil {
+		return nil, nil, err
+	}
+	defer ether.Close()
+
+	c := ether.Client()
+
+	tip, err := internal.GethRequestWithBackOff(
+		ether.config.backoffConfig,
+		ether.config.requestTimeout,
+		c.SuggestGasTipCap,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	header, err := internal.GethRequestArgWithBackOff(
+		ether.config.backoffConfig,
+		ether.config.requestTimeout,
+		c.HeaderByNumber,
+		(*big.Int)(nil),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	if header.BaseFee == nil {
+		return nil, nil, constant.ErrChainNotSupportEIP1559
+	}
+
+	maxFee := new(big.Int).Add(new(big.Int).Lsh(header.BaseFee, 1), tip)
+	return tip, maxFee, nil
+}
+
 func (ether *Ether) Call(tx types.TransactionRequest, blockTag string) (string, error) {
 	if err := validate.BlockTag(blockTag); err != nil {
 		return "", err

--- a/ether/ether_core_test.go
+++ b/ether/ether_core_test.go
@@ -1926,6 +1926,159 @@ func TestEther_SuggestGasPrice(t *testing.T) {
 	})
 }
 
+func TestEther_SuggestGasTipCap(t *testing.T) {
+	t.Run("normal case", func(t *testing.T) {
+		t.Run("success request", func(t *testing.T) {
+			// Arrange
+			ether := newEtherApiForTest()
+			alchemyMock := newAlchemyMockOnEtherTest(t)
+			defer alchemyMock.DeactivateAndReset()
+
+			// Mock
+			alchemyMock.RegisterResponderOnce("eth_maxPriorityFeePerGas", `{"jsonrpc":"2.0","id":1,"result":"0x3B9ACA00"}`)
+
+			// Act
+			result, err := ether.SuggestGasTipCap()
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, big.NewInt(1_000_000_000), result)
+		})
+	})
+
+	t.Run("error case", func(t *testing.T) {
+		t.Run("if cannot create ethClient, return err", func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			// Arrange
+			ether := newEtherApiForTest()
+
+			// Mock
+			patches.ApplyMethod(
+				reflect.TypeOf(ether),
+				"SetEthClient",
+				func(_ *eth.Ether) error {
+					return errors.New("error")
+				},
+			)
+
+			// Act
+			_, err := ether.SuggestGasTipCap()
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if failed to get tip cap, return error", func(t *testing.T) {
+			// Arrange
+			ether := newEtherApiForTest()
+
+			// Act
+			_, err := ether.SuggestGasTipCap()
+
+			// Assert
+			assert.Error(t, err)
+		})
+	})
+}
+
+func TestEther_SuggestEIP1559Fees(t *testing.T) {
+	t.Run("normal case", func(t *testing.T) {
+		t.Run("success on EIP-1559 chain", func(t *testing.T) {
+			// Arrange
+			ether, cleanup := newSimulatedEtherForTest(t)
+			defer cleanup()
+
+			// Act
+			tip, maxFee, err := ether.SuggestEIP1559Fees()
+
+			// Assert
+			assert.NoError(t, err)
+			assert.NotNil(t, tip)
+			assert.NotNil(t, maxFee)
+			assert.True(t, maxFee.Cmp(tip) >= 0)
+		})
+	})
+
+	t.Run("error case", func(t *testing.T) {
+		t.Run("if cannot create ethClient, return err", func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			// Arrange
+			ether := newEtherApiForTest()
+
+			// Mock
+			patches.ApplyMethod(
+				reflect.TypeOf(ether),
+				"SetEthClient",
+				func(_ *eth.Ether) error {
+					return errors.New("error")
+				},
+			)
+
+			// Act
+			_, _, err := ether.SuggestEIP1559Fees()
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if failed to get tip cap, return error", func(t *testing.T) {
+			// Arrange
+			ether := newEtherApiForTest()
+
+			// Act
+			_, _, err := ether.SuggestEIP1559Fees()
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("if failed to get header, return error", func(t *testing.T) {
+			// Arrange
+			ether := newEtherApiForTest()
+			alchemyMock := newAlchemyMockOnEtherTest(t)
+			defer alchemyMock.DeactivateAndReset()
+
+			// Mock: tip succeeds, but no block mock
+			alchemyMock.RegisterResponderOnce("eth_maxPriorityFeePerGas", `{"jsonrpc":"2.0","id":1,"result":"0x3B9ACA00"}`)
+
+			// Act
+			_, _, err := ether.SuggestEIP1559Fees()
+
+			// Assert
+			assert.Error(t, err)
+		})
+
+		t.Run("on non-EIP-1559 chain (nil baseFee), return ErrChainNotSupportEIP1559", func(t *testing.T) {
+			// Arrange
+			ether := newEtherApiForTest()
+			alchemyMock := newAlchemyMockOnEtherTest(t)
+			defer alchemyMock.DeactivateAndReset()
+
+			// Mock: tip succeeds; legacy block header without baseFeePerGas
+			alchemyMock.RegisterResponderOnce("eth_maxPriorityFeePerGas", `{"jsonrpc":"2.0","id":1,"result":"0x3B9ACA00"}`)
+			alchemyMock.RegisterResponderOnce("eth_getBlockByNumber", `{"jsonrpc":"2.0","id":1,"result":{`+
+				`"parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000",`+
+				`"sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",`+
+				`"stateRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",`+
+				`"transactionsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",`+
+				`"receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",`+
+				`"logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",`+
+				`"difficulty":"0x0","number":"0x1","gasLimit":"0x1c9c380","gasUsed":"0x0",`+
+				`"timestamp":"0x5e9fe3a2","extraData":"0x"}}`)
+
+			// Act
+			_, _, err := ether.SuggestEIP1559Fees()
+
+			// Assert
+			assert.ErrorIs(t, err, constant.ErrChainNotSupportEIP1559)
+		})
+	})
+}
+
 func TestEther_SendRawTransaction(t *testing.T) {
 	t.Run("error case", func(t *testing.T) {
 		// Arrange

--- a/ether/ether_simulated_test.go
+++ b/ether/ether_simulated_test.go
@@ -79,6 +79,32 @@ func simSendDeployTx(t *testing.T, e *eth.Ether) common.Hash {
 	return simSign(t, e, nil, common.FromHex(artifacts.PotetoStorageMetaData.Bin))
 }
 
+func TestEther_SuggestGasTipCap_Simulated(t *testing.T) {
+	t.Run("returns tip on simulated EIP-1559 backend", func(t *testing.T) {
+		e, cleanup := newSimulatedEtherForTest(t)
+		defer cleanup()
+
+		tip, err := e.SuggestGasTipCap()
+
+		assert.NoError(t, err)
+		assert.NotNil(t, tip)
+	})
+}
+
+func TestEther_SuggestEIP1559Fees_Simulated(t *testing.T) {
+	t.Run("returns tip and maxFee on simulated EIP-1559 backend", func(t *testing.T) {
+		e, cleanup := newSimulatedEtherForTest(t)
+		defer cleanup()
+
+		tip, maxFee, err := e.SuggestEIP1559Fees()
+
+		assert.NoError(t, err)
+		assert.NotNil(t, tip)
+		assert.NotNil(t, maxFee)
+		assert.True(t, maxFee.Cmp(tip) >= 0)
+	})
+}
+
 func TestEther_NewSimulatedApi(t *testing.T) {
 	t.Run("Client returns a usable simulated client", func(t *testing.T) {
 		e, cleanup := newSimulatedEtherForTest(t)

--- a/namespace/core_namespace.go
+++ b/namespace/core_namespace.go
@@ -23,6 +23,19 @@ type ICore interface {
 	/* Returns the best guess of the current gas price to use in a transaction. */
 	GetGasPrice() (*big.Int, error)
 
+	/*
+		SuggestGasTipCap returns the suggested maxPriorityFeePerGas (EIP-1559 tip)
+		via eth_maxPriorityFeePerGas.
+	*/
+	SuggestGasTipCap() (*big.Int, error)
+
+	/*
+		SuggestEIP1559Fees returns (maxPriorityFeePerGas, maxFeePerGas) ready to use in a
+		TransactionRequest. maxFeePerGas is derived as baseFee*2 + maxPriorityFeePerGas.
+		Returns an error on chains that do not support EIP-1559.
+	*/
+	SuggestEIP1559Fees() (maxPriorityFeePerGas *big.Int, maxFeePerGas *big.Int, err error)
+
 	/* Returns the number of p2p peers as reported by the net_peerCount method. */
 	PeerCount() (uint64, error)
 
@@ -325,6 +338,14 @@ func (c *Core) LookupAddress(address string) (string, error) {
 
 func (c *Core) LookupAddressBy(registryAddress string, address string) (string, error) {
 	return c.ether.LookupAddressBy(registryAddress, address)
+}
+
+func (c *Core) SuggestGasTipCap() (*big.Int, error) {
+	return c.ether.SuggestGasTipCap()
+}
+
+func (c *Core) SuggestEIP1559Fees() (*big.Int, *big.Int, error) {
+	return c.ether.SuggestEIP1559Fees()
 }
 
 func (c *Core) GetBlock(blockHashOrBlockTag types.BlockTagOrHash) (*gethTypes.Block, error) {

--- a/namespace/core_namespace_test.go
+++ b/namespace/core_namespace_test.go
@@ -172,6 +172,122 @@ func TestCore_GetGasPrice(t *testing.T) {
 	})
 }
 
+func TestCore_SuggestGasTipCap(t *testing.T) {
+	// Arrange
+	api := newEtherApi()
+	core := namespace.NewCore(api).(*namespace.Core)
+
+	t.Run("normal case:", func(t *testing.T) {
+		t.Run("return tip cap", func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			// Arrange
+			expected := big.NewInt(1_000_000_000)
+
+			// Mock
+			patches.ApplyMethod(
+				reflect.TypeOf(api),
+				"SuggestGasTipCap",
+				func(_ *ether.Ether) (*big.Int, error) {
+					return expected, nil
+				},
+			)
+
+			// Act
+			tip, err := core.SuggestGasTipCap()
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, expected, tip)
+		})
+	})
+
+	t.Run("error case:", func(t *testing.T) {
+		t.Run("propagates error from ether", func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			// Arrange
+			errExpected := errors.New("error")
+
+			// Mock
+			patches.ApplyMethod(
+				reflect.TypeOf(api),
+				"SuggestGasTipCap",
+				func(_ *ether.Ether) (*big.Int, error) {
+					return nil, errExpected
+				},
+			)
+
+			// Act
+			tip, err := core.SuggestGasTipCap()
+
+			// Assert
+			assert.ErrorIs(t, errExpected, err)
+			assert.Nil(t, tip)
+		})
+	})
+}
+
+func TestCore_SuggestEIP1559Fees(t *testing.T) {
+	// Arrange
+	api := newEtherApi()
+	core := namespace.NewCore(api).(*namespace.Core)
+
+	t.Run("normal case:", func(t *testing.T) {
+		t.Run("return tip and maxFee", func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			// Arrange
+			expectedTip := big.NewInt(1_000_000_000)
+			expectedMaxFee := big.NewInt(3_000_000_000)
+
+			// Mock
+			patches.ApplyMethod(
+				reflect.TypeOf(api),
+				"SuggestEIP1559Fees",
+				func(_ *ether.Ether) (*big.Int, *big.Int, error) {
+					return expectedTip, expectedMaxFee, nil
+				},
+			)
+
+			// Act
+			tip, maxFee, err := core.SuggestEIP1559Fees()
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, expectedTip, tip)
+			assert.Equal(t, expectedMaxFee, maxFee)
+		})
+	})
+
+	t.Run("error case:", func(t *testing.T) {
+		t.Run("propagates ErrChainNotSupportEIP1559", func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			// Mock
+			patches.ApplyMethod(
+				reflect.TypeOf(api),
+				"SuggestEIP1559Fees",
+				func(_ *ether.Ether) (*big.Int, *big.Int, error) {
+					return nil, nil, constant.ErrChainNotSupportEIP1559
+				},
+			)
+
+			// Act
+			tip, maxFee, err := core.SuggestEIP1559Fees()
+
+			// Assert
+			assert.ErrorIs(t, err, constant.ErrChainNotSupportEIP1559)
+			assert.Nil(t, tip)
+			assert.Nil(t, maxFee)
+		})
+	})
+}
+
 func TestCore_PeerCount(t *testing.T) {
 	// Arrange
 	api := newEtherApi()

--- a/types/ether_api.go
+++ b/types/ether_api.go
@@ -147,6 +147,19 @@ type EtherApi interface {
 	SuggestGasPrice() (*big.Int, error)
 
 	/*
+		SuggestGasTipCap returns the suggested maxPriorityFeePerGas (eth_maxPriorityFeePerGas)
+		for EIP-1559 transactions.
+	*/
+	SuggestGasTipCap() (*big.Int, error)
+
+	/*
+		SuggestEIP1559Fees returns (maxPriorityFeePerGas, maxFeePerGas) ready to use in a
+		TransactionRequest. maxFeePerGas is derived as baseFee*2 + maxPriorityFeePerGas.
+		Returns an error on chains that do not support EIP-1559.
+	*/
+	SuggestEIP1559Fees() (maxPriorityFeePerGas *big.Int, maxFeePerGas *big.Int, err error)
+
+	/*
 		Read method call for Any Smart Contract
 	*/
 	CallReadMethod(


### PR DESCRIPTION
## Summary

- Add `SuggestGasTipCap() (*big.Int, error)` — wraps `eth_maxPriorityFeePerGas` via geth's `SuggestGasTipCap`
- Add `SuggestEIP1559Fees() (tip, maxFeePerGas *big.Int, err error)` — returns both EIP-1559 fee values where `maxFeePerGas = baseFee*2 + tip`; returns `ErrChainNotSupportEIP1559` when the latest block header has no `baseFeePerGas`
- Both methods are exposed on `EtherApi`, `ICore`, and the `Core` namespace wrapper

Closes #458

## Changes

- `constant/errors.go` — `ErrChainNotSupportEIP1559`
- `types/ether_api.go` — two new interface methods
- `ether/ether.go` — implementations (`SuggestGasTipCap`, `SuggestEIP1559Fees`)
- `namespace/core_namespace.go` — `ICore` interface + `Core` delegation
- Tests: `ether/ether_core_test.go`, `namespace/core_namespace_test.go`, `e2e/rpc_test.go`
- Docs: `docs/docs/core-namespace/SuggestGasTipCap.md`, `SuggestEIP1559Fees.md`

## Design notes

Non-EIP-1559 detection relies solely on `header.BaseFee == nil` (the authoritative on-chain signal) rather than a static chain-ID list pre-check, which would have added an extra `eth_chainId` round-trip for no benefit since the header fetch already detects any legacy chain.

## Test plan

- [x] `go test ./ether/... -run TestEther_SuggestGasTipCap` — success + 2 error paths
- [x] `go test ./ether/... -run TestEther_SuggestEIP1559Fees` — success (simulated backend) + 4 error paths including nil-baseFee legacy block
- [x] `go test ./namespace/... -run TestCore_SuggestGasTipCap|TestCore_SuggestEIP1559Fees`
- [x] `just ut` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)