### PR TITLE
feat: GetAssetTransfers in CoreNamespace (alchemy_getAssetTransfers)

### DIFF
--- a/constant/errors.go
+++ b/constant/errors.go
@@ -61,6 +61,7 @@ var (
 	ErrENSNameNotFound                  = errors.New("ENS name not found for address")
 	ErrENSNotSupportedOnNetwork         = errors.New("ENS not available on this network")
 	ErrChainNotSupportEIP1559           = errors.New("chain does not support EIP-1559")
+	ErrFailedToMapAssetTransfers        = errors.New("failed to map asset transfers response")
 )
 
 var HttpClientErrorCodeList = []int{

--- a/constant/ether_methods.go
+++ b/constant/ether_methods.go
@@ -29,4 +29,5 @@ var (
 	Alchemy_GetTokenBalances    = "alchemy_getTokenBalances"
 	Alchemy_GetTokenMetadata    = "alchemy_getTokenMetadata"
 	Alchemy_TransactionReceipts = "alchemy_getTransactionReceipts"
+	Alchemy_GetAssetTransfers   = "alchemy_getAssetTransfers"
 )

--- a/docs/docs/core-namespace/GetAssetTransfers.md
+++ b/docs/docs/core-namespace/GetAssetTransfers.md
@@ -1,0 +1,64 @@
+![](https://img.shields.io/badge/alchemy-only-orange)
+
+Fetches asset transfer history for an address using Alchemy's `alchemy_getAssetTransfers` endpoint.
+Supports pagination via `PageKey`.
+
+> **Note:** This is an Alchemy-specific API. It is **not** available on non-Alchemy endpoints such as simulated backends.
+
+- types: `types.AssetTransfersResponse`
+- method: `alchemy_getAssetTransfers`
+  - refs: https://docs.alchemy.com/reference/alchemy-getassettransfers
+
+```go
+func GetAssetTransfers(params types.AssetTransfersParams) (types.AssetTransfersResponse, error)
+```
+
+### AssetTransfersParams
+
+| Field               | Type       | Description                                                                 |
+| ------------------- | ---------- | --------------------------------------------------------------------------- |
+| `FromBlock`         | `string`   | Start block (hex or `"latest"`). Optional.                                  |
+| `ToBlock`           | `string`   | End block (hex or `"latest"`). Optional.                                    |
+| `FromAddress`       | `string`   | Filter by sender address. Optional.                                         |
+| `ToAddress`         | `string`   | Filter by recipient address. Optional.                                      |
+| `ContractAddresses` | `[]string` | Filter by contract addresses (ERC-20/721/1155 only). Optional.             |
+| `Category`          | `[]string` | **Required.** Transfer categories: `"external"`, `"internal"`, `"erc20"`, `"erc721"`, `"erc1155"`, `"specialnft"`. |
+| `WithMetadata`      | `bool`     | Include block timestamp in `Metadata`. Defaults to `false`.                |
+| `ExcludeZeroValue`  | `bool`     | Exclude transfers with zero value. Defaults to `false`.                    |
+| `MaxCount`          | `int`      | Max results per page (`0` uses the API default of 1000).                   |
+| `PageKey`           | `string`   | Pagination cursor from a previous response. Optional.                       |
+
+```go
+func main() {
+	...
+	alchemy := gas.NewAlchemy(setting)
+
+	// Fetch all external and ERC-20 transfers from an address
+	res, err := alchemy.Core.GetAssetTransfers(
+		types.AssetTransfersParams{
+			FromAddress:      "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+			Category:         []string{"external", "erc20"},
+			ExcludeZeroValue: true,
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, transfer := range res.Transfers {
+		fmt.Printf("%s: %s -> %s (%s)\n", transfer.BlockNum, transfer.From, transfer.To, transfer.Asset)
+	}
+
+	// Paginate using PageKey
+	if res.PageKey != "" {
+		next, _ := alchemy.Core.GetAssetTransfers(
+			types.AssetTransfersParams{
+				FromAddress: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+				Category:    []string{"external", "erc20"},
+				PageKey:     res.PageKey,
+			},
+		)
+		_ = next
+	}
+}
+```

--- a/ether/ether.go
+++ b/ether/ether.go
@@ -1032,3 +1032,55 @@ func (ether *Ether) CallReadMethod(
 	}
 	return output, nil
 }
+
+// assetTransfersReq is the JSON-serializable form sent to alchemy_getAssetTransfers.
+type assetTransfersReq struct {
+	FromBlock         string   `json:"fromBlock,omitempty"`
+	ToBlock           string   `json:"toBlock,omitempty"`
+	FromAddress       string   `json:"fromAddress,omitempty"`
+	ToAddress         string   `json:"toAddress,omitempty"`
+	ContractAddresses []string `json:"contractAddresses,omitempty"`
+	Category          []string `json:"category"`
+	WithMetadata      bool     `json:"withMetadata"`
+	ExcludeZeroValue  bool     `json:"excludeZeroValue"`
+	MaxCount          string   `json:"maxCount,omitempty"`
+	PageKey           string   `json:"pageKey,omitempty"`
+}
+
+func (ether *Ether) GetAssetTransfers(params types.AssetTransfersParams) (types.AssetTransfersResponse, error) {
+	req := assetTransfersReq{
+		FromBlock:         params.FromBlock,
+		ToBlock:           params.ToBlock,
+		FromAddress:       strings.ToLower(params.FromAddress),
+		ToAddress:         strings.ToLower(params.ToAddress),
+		ContractAddresses: params.ContractAddresses,
+		Category:          params.Category,
+		WithMetadata:      params.WithMetadata,
+		ExcludeZeroValue:  params.ExcludeZeroValue,
+		PageKey:           params.PageKey,
+	}
+	if params.MaxCount > 0 {
+		req.MaxCount = hexutil.EncodeUint64(uint64(params.MaxCount))
+	}
+
+	result, err := ether.provider.Send(
+		constant.Alchemy_GetAssetTransfers,
+		types.RequestArgs{req},
+	)
+	if err != nil {
+		return types.AssetTransfersResponse{}, err
+	}
+
+	resultMap, ok := result.(map[string]any)
+	if !ok {
+		return types.AssetTransfersResponse{}, constant.ErrUnexpectedResponseType
+	}
+
+	var response types.AssetTransfersResponse
+	// WeakDecode is required: the Alchemy API returns null for some string fields
+	// (e.g. erc721TokenId, rawContract.address) which strict Decode cannot coerce to "".
+	if err := mapstructure.WeakDecode(resultMap, &response); err != nil {
+		return types.AssetTransfersResponse{}, constant.ErrFailedToMapAssetTransfers
+	}
+	return response, nil
+}

--- a/ether/ether_core_test.go
+++ b/ether/ether_core_test.go
@@ -2166,3 +2166,147 @@ func TestEther_ChainID(t *testing.T) {
 		})
 	})
 }
+
+func TestEther_GetAssetTransfers(t *testing.T) {
+	provider := newProviderForTest()
+	etherApi := newNilEtherApiForTest(provider)
+
+	val := float64(1.5)
+	expectedResponse := map[string]any{
+		"transfers": []any{
+			map[string]any{
+				"blockNum":        "0xf1d1c6",
+				"uniqueId":        "0xabc:external",
+				"hash":            "0xabc",
+				"from":            "0x123",
+				"to":              "0x456",
+				"value":           val,
+				"erc721TokenId":   nil,
+				"erc1155Metadata": nil,
+				"tokenId":         nil,
+				"asset":           "ETH",
+				"category":        "external",
+				"rawContract": map[string]any{
+					"value":   "0x16345785d8a0000",
+					"address": nil,
+					"decimal": nil,
+				},
+				"metadata": nil,
+			},
+		},
+		"pageKey": "nextpage",
+	}
+	expected := types.AssetTransfersResponse{
+		Transfers: []types.AssetTransfer{
+			{
+				BlockNum:        "0xf1d1c6",
+				UniqueId:        "0xabc:external",
+				Hash:            "0xabc",
+				From:            "0x123",
+				To:              "0x456",
+				Value:           &val,
+				Erc721TokenId:   "",
+				Erc1155Metadata: nil,
+				TokenId:         "",
+				Asset:           "ETH",
+				Category:        "external",
+				RawContract: types.RawContract{
+					Value:   "0x16345785d8a0000",
+					Address: "",
+					Decimal: "",
+				},
+				Metadata: nil,
+			},
+		},
+		PageKey: "nextpage",
+	}
+
+	t.Run("normal case:", func(t *testing.T) {
+		t.Run("calls alchemy_getAssetTransfers and returns decoded response", func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			patches.ApplyMethod(
+				reflect.TypeOf(provider),
+				"Send",
+				func(_ *gas.AlchemyProvider, method string, _ types.RequestArgs) (any, error) {
+					assert.Equal(t, constant.Alchemy_GetAssetTransfers, method)
+					return expectedResponse, nil
+				},
+			)
+
+			actual, err := etherApi.GetAssetTransfers(types.AssetTransfersParams{
+				Category: []string{"external"},
+			})
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+		})
+	})
+
+	t.Run("error case:", func(t *testing.T) {
+		t.Run("if provider.Send fails, return error", func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			expectedErr := errors.New("provider error")
+			patches.ApplyMethod(
+				reflect.TypeOf(provider),
+				"Send",
+				func(_ *gas.AlchemyProvider, _ string, _ types.RequestArgs) (any, error) {
+					return nil, expectedErr
+				},
+			)
+
+			_, err := etherApi.GetAssetTransfers(types.AssetTransfersParams{
+				Category: []string{"external"},
+			})
+
+			assert.ErrorIs(t, err, expectedErr)
+		})
+
+		t.Run("if result is not map[string]any -> ErrUnexpectedResponseType", func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			patches.ApplyMethod(
+				reflect.TypeOf(provider),
+				"Send",
+				func(_ *gas.AlchemyProvider, _ string, _ types.RequestArgs) (any, error) {
+					return "unexpected", nil
+				},
+			)
+
+			_, err := etherApi.GetAssetTransfers(types.AssetTransfersParams{
+				Category: []string{"external"},
+			})
+
+			assert.ErrorIs(t, err, constant.ErrUnexpectedResponseType)
+		})
+
+		t.Run("if mapstructure decode fails -> ErrFailedToMapAssetTransfers", func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			patches.ApplyMethod(
+				reflect.TypeOf(provider),
+				"Send",
+				func(_ *gas.AlchemyProvider, _ string, _ types.RequestArgs) (any, error) {
+					return expectedResponse, nil
+				},
+			)
+			patches.ApplyFunc(
+				mapstructure.WeakDecode,
+				func(_ any, _ any) error {
+					return errors.New("decode error")
+				},
+			)
+
+			_, err := etherApi.GetAssetTransfers(types.AssetTransfersParams{
+				Category: []string{"external"},
+			})
+
+			assert.ErrorIs(t, err, constant.ErrFailedToMapAssetTransfers)
+		})
+	})
+}

--- a/namespace/core_namespace.go
+++ b/namespace/core_namespace.go
@@ -153,6 +153,16 @@ type ICore interface {
 		Returns an error when no reverse record is registered.
 	*/
 	LookupAddressBy(registryAddress string, address string) (string, error)
+
+	/*
+		GetAssetTransfers fetches asset transfer history matching the given params
+		using the alchemy_getAssetTransfers endpoint. Pagination is supported via
+		AssetTransfersParams.PageKey / AssetTransfersResponse.PageKey.
+
+		NOTE: This is an Alchemy-specific API and is not available on non-Alchemy
+		endpoints such as simulated backends.
+	*/
+	GetAssetTransfers(params types.AssetTransfersParams) (types.AssetTransfersResponse, error)
 }
 
 type Core struct {
@@ -342,6 +352,10 @@ func (c *Core) LookupAddressBy(registryAddress string, address string) (string, 
 
 func (c *Core) SuggestGasTipCap() (*big.Int, error) {
 	return c.ether.SuggestGasTipCap()
+}
+
+func (c *Core) GetAssetTransfers(params types.AssetTransfersParams) (types.AssetTransfersResponse, error) {
+	return c.ether.GetAssetTransfers(params)
 }
 
 func (c *Core) SuggestEIP1559Fees() (*big.Int, *big.Int, error) {

--- a/namespace/core_namespace_test.go
+++ b/namespace/core_namespace_test.go
@@ -1423,3 +1423,68 @@ func TestCore_GetBlock(t *testing.T) {
 		})
 	})
 }
+
+func TestCore_GetAssetTransfers(t *testing.T) {
+	api := newEtherApi()
+	core := namespace.NewCore(api).(*namespace.Core)
+
+	val := float64(1.5)
+	expected := types.AssetTransfersResponse{
+		Transfers: []types.AssetTransfer{
+			{
+				BlockNum: "0xf1d1c6",
+				Hash:     "0xabc",
+				From:     "0x123",
+				To:       "0x456",
+				Value:    &val,
+				Asset:    "ETH",
+				Category: "external",
+			},
+		},
+		PageKey: "",
+	}
+
+	t.Run("normal case:", func(t *testing.T) {
+		t.Run("delegates to ether.GetAssetTransfers and returns response", func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			patches.ApplyMethod(
+				reflect.TypeOf(api),
+				"GetAssetTransfers",
+				func(_ *ether.Ether, _ types.AssetTransfersParams) (types.AssetTransfersResponse, error) {
+					return expected, nil
+				},
+			)
+
+			actual, err := core.GetAssetTransfers(types.AssetTransfersParams{
+				Category: []string{"external"},
+			})
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+		})
+	})
+
+	t.Run("error case:", func(t *testing.T) {
+		t.Run("propagates error from ether.GetAssetTransfers", func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			expectedErr := errors.New("provider error")
+			patches.ApplyMethod(
+				reflect.TypeOf(api),
+				"GetAssetTransfers",
+				func(_ *ether.Ether, _ types.AssetTransfersParams) (types.AssetTransfersResponse, error) {
+					return types.AssetTransfersResponse{}, expectedErr
+				},
+			)
+
+			_, err := core.GetAssetTransfers(types.AssetTransfersParams{
+				Category: []string{"external"},
+			})
+
+			assert.ErrorIs(t, err, expectedErr)
+		})
+	})
+}

--- a/types/asset_transfer.go
+++ b/types/asset_transfer.go
@@ -1,0 +1,56 @@
+package types
+
+// AssetTransfersParams is the input for GetAssetTransfers.
+// Category is required; all other fields are optional.
+// MaxCount of 0 uses the Alchemy API default (1000).
+//
+// NOTE: This method is Alchemy-specific and is not available on
+// non-Alchemy endpoints such as simulated backends.
+type AssetTransfersParams struct {
+	FromBlock         string
+	ToBlock           string
+	FromAddress       string
+	ToAddress         string
+	ContractAddresses []string
+	Category          []string // "external","internal","erc20","erc721","erc1155","specialnft"
+	WithMetadata      bool
+	ExcludeZeroValue  bool
+	MaxCount          int // 0 → API default (1000)
+	PageKey           string
+}
+
+type Erc1155Metadata struct {
+	TokenId string
+	Value   string
+}
+
+type RawContract struct {
+	Value   string
+	Address string
+	Decimal string
+}
+
+type AssetTransferMetadata struct {
+	BlockTimestamp string
+}
+
+type AssetTransfer struct {
+	BlockNum        string
+	UniqueId        string
+	Hash            string
+	From            string
+	To              string
+	Value           *float64
+	Erc721TokenId   string
+	Erc1155Metadata []Erc1155Metadata
+	TokenId         string
+	Asset           string
+	Category        string
+	RawContract     RawContract
+	Metadata        *AssetTransferMetadata
+}
+
+type AssetTransfersResponse struct {
+	Transfers []AssetTransfer
+	PageKey   string
+}

--- a/types/ether_api.go
+++ b/types/ether_api.go
@@ -312,4 +312,12 @@ type EtherApi interface {
 		callData []byte,
 		unpack func([]byte) (any, error),
 	) (any, error)
+
+	/*
+		GetAssetTransfers fetches asset transfer history matching the given params.
+
+		NOTE: This is an Alchemy-specific API (alchemy_getAssetTransfers).
+		It is not available on non-Alchemy endpoints such as simulated backends.
+	*/
+	GetAssetTransfers(params AssetTransfersParams) (AssetTransfersResponse, error)
 }


### PR DESCRIPTION
## Summary

- Adds `GetAssetTransfers` to `ICore` and `CoreNamespace`, wrapping the `alchemy_getAssetTransfers` endpoint
- Introduces `AssetTransfersParams` / `AssetTransfersResponse` / `AssetTransfer` types in `types/asset_transfer.go`
- Clearly documented as Alchemy-only (not available on simulated backends) in both the interface and docs
- Pagination supported via `AssetTransfersParams.PageKey` / `AssetTransfersResponse.PageKey`

## Notes

- Uses `mapstructure.WeakDecode` (not `Decode`) because the Alchemy API returns `null` for optional string fields (e.g. `erc721TokenId`, `rawContract.address`) — weak decoding coerces these to `""` instead of erroring. A comment documents this at the call site.
- `MaxCount int` is encoded as a hex string via `hexutil.EncodeUint64` (consistent with codebase convention) before being sent to the API.
- e2e tests omitted: no Alchemy endpoint available in the e2e environment.

## Test plan

- [x] `TestEther_GetAssetTransfers` — normal decode, provider error, unexpected type, mapstructure failure
- [x] `TestCore_GetAssetTransfers` — delegation and error propagation
- [x] `just ut` — all packages green

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)