### PR TITLE
feat: add a WebSocket provider (ws_provider) alongside http_provider

### DIFF
--- a/constant/errors.go
+++ b/constant/errors.go
@@ -52,6 +52,7 @@ var (
 	ErrNilSnapshotId                    = errors.New("snapshot id must not be nil")
 	ErrUnexpectedNoContractAddress      = errors.New("unexpected no contract address")
 	ErrUnSupportSimulatedMethod         = errors.New("unsupported method on simulated backend")
+	ErrProviderEthNotSet                = errors.New("provider eth client is not set")
 	ErrUnexpectedNilSimulatedBackend    = errors.New("unexpected nil of simulated backend")
 	ErrUnexpectedSnapshotId             = errors.New("unexpected snapshot id")
 	ErrMismatchedArrayLength            = errors.New("array arguments must have the same length")

--- a/docs/docs/setting/alchemySetting.md
+++ b/docs/docs/setting/alchemySetting.md
@@ -91,9 +91,9 @@ func main() {
 
 The WebSocket connection is **long-lived**: a per-call `Close()` is a no-op, so the socket survives across calls. Call `Shutdown()` (via `alchemy.GetProvider().Eth().Shutdown()`) to close it explicitly when you are finished.
 
-#### HTTP-only methods
+#### Unified transport
 
-Alchemy JSON-RPC methods that go through `provider.Send` — e.g. `GetBalance`, `GetLogs`, `GetTokenBalances`, `GetAssetTransfers`, `Call` — are **HTTP-only** and are not served over the WebSocket. A WebSocket `Alchemy` is for geth-client methods (and subscriptions). If you need both at once, create two `Alchemy` instances: one default (HTTP) and one with `UseWebsocket: true`.
+A WebSocket `Alchemy` routes **everything over the same socket**. Alchemy JSON-RPC methods that go through `provider.Send` — e.g. `GetBalance`, `GetLogs`, `GetTokenBalances`, `GetAssetTransfers`, `Call` — are dispatched over the persistent WebSocket connection (via the ws provider), alongside the geth-client methods and `eth_subscribe` subscriptions. A single `Alchemy` instance therefore covers calls and subscriptions; you no longer need a separate HTTP instance for `Send`-based methods.
 
 #### Reused settings on WebSocket
 

--- a/e2e/ws_rpc_test.go
+++ b/e2e/ws_rpc_test.go
@@ -32,11 +32,9 @@ func newWsAlchemy(t *testing.T) gas.Alchemy {
 	return a
 }
 
-// TestScenario_Ws_BaseMethod verifies geth-client-backed RPC calls round-trip
-// over a persistent WebSocket connection to anvil.
-//
-// NOTE: provider.Send-based methods (GetBalance, GetLogs, ...) are HTTP-only, so
-// they are intentionally not exercised here — a ws Alchemy is for the geth client.
+// TestScenario_Ws_BaseMethod verifies that both geth-client-backed RPC calls and
+// provider.Send-based methods round-trip over a single persistent WebSocket
+// connection to anvil — a ws Alchemy serves the whole surface over one socket.
 func TestScenario_Ws_BaseMethod(t *testing.T) {
 	wsAlchemy := newWsAlchemy(t)
 	// Close() is a no-op on ws, so the socket is persistent; shut it down explicitly.
@@ -81,6 +79,13 @@ func TestScenario_Ws_BaseMethod(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, 1, gasLimit.Cmp(big.NewInt(0)))
+	})
+
+	t.Run("GetBalance over ws (provider.Send routed over the socket)", func(t *testing.T) {
+		balance, err := wsAlchemy.Core.GetBalance(initAddress, "latest")
+
+		assert.Nil(t, err)
+		assert.Equal(t, 1, balance.Cmp(big.NewInt(0)))
 	})
 
 	t.Run("persistent ws client survives a per-call Close", func(t *testing.T) {

--- a/gas/alchemy.go
+++ b/gas/alchemy.go
@@ -24,7 +24,7 @@ func NewAlchemy(setting AlchemySetting) (Alchemy, error) {
 		return Alchemy{}, err
 	}
 
-	alchemyProvider := NewAlchemyProvider(alchemyConfig)
+	alchemyProvider := newProvider(alchemyConfig)
 	eth := ether.NewEtherApi(
 		alchemyProvider,
 		alchemyConfig.toEtherApiConfig(),
@@ -53,4 +53,13 @@ func NewAlchemy(setting AlchemySetting) (Alchemy, error) {
 
 func (gas *Alchemy) GetProvider() types.IAlchemyProvider {
 	return gas.provider
+}
+
+// newProvider picks the transport-appropriate provider: ws/wss endpoints route
+// over the persistent websocket socket, everything else over HTTP.
+func newProvider(config AlchemyConfig) types.IAlchemyProvider {
+	if config.isWebSocket() {
+		return NewWsAlchemyProvider(config)
+	}
+	return NewAlchemyProvider(config)
 }

--- a/gas/alchemy_config.go
+++ b/gas/alchemy_config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/poteto-go/go-alchemy-sdk/ether"
@@ -105,6 +106,12 @@ func defaultIsPrivateNetwork(setting AlchemySetting) bool {
 
 func (config *AlchemyConfig) GetUrl() string {
 	return config.url
+}
+
+// isWebSocket reports whether the resolved url is a ws/wss endpoint, mirroring
+// Ether.isWebSocket so provider selection and transport selection agree.
+func (config *AlchemyConfig) isWebSocket() bool {
+	return strings.HasPrefix(config.url, "ws") // ws:// and wss://
 }
 
 // To avoid circle import

--- a/gas/alchemy_test.go
+++ b/gas/alchemy_test.go
@@ -28,6 +28,20 @@ func TestNewAlchemy(t *testing.T) {
 	assert.NotNil(t, alchemy.Debug)
 }
 
+func TestNewAlchemy_SelectsProviderByScheme(t *testing.T) {
+	t.Run("http setting -> AlchemyProvider", func(t *testing.T) {
+		alchemy, err := NewAlchemy(AlchemySetting{ApiKey: "hoge", Network: "fuga"})
+		assert.NoError(t, err)
+		assert.IsType(t, &AlchemyProvider{}, alchemy.GetProvider())
+	})
+
+	t.Run("ws setting -> WsAlchemyProvider", func(t *testing.T) {
+		alchemy, err := NewAlchemy(AlchemySetting{ApiKey: "hoge", Network: "fuga", UseWebsocket: true})
+		assert.NoError(t, err)
+		assert.IsType(t, &WsAlchemyProvider{}, alchemy.GetProvider())
+	})
+}
+
 func TestAlchemy_GetProvider(t *testing.T) {
 	// Arrange
 	setting := AlchemySetting{

--- a/gas/ws_provider.go
+++ b/gas/ws_provider.go
@@ -1,0 +1,104 @@
+package gas
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/poteto-go/go-alchemy-sdk/constant"
+	"github.com/poteto-go/go-alchemy-sdk/types"
+)
+
+// WsAlchemyProvider routes JSON-RPC requests and eth_subscribe streams over the
+// persistent websocket rpc.Client owned by Ether (see ether.setWsEthClient).
+// Unlike AlchemyProvider it does not dial its own transport: reusing Ether's
+// socket keeps a single long-lived ws connection per Alchemy instance.
+type WsAlchemyProvider struct {
+	config AlchemyConfig
+	eth    types.EtherApi
+}
+
+// compile-time assertions: WsAlchemyProvider serves both the base provider
+// surface and the focused subscribe path.
+var (
+	_ types.IAlchemyProvider   = (*WsAlchemyProvider)(nil)
+	_ types.ISubscribeProvider = (*WsAlchemyProvider)(nil)
+)
+
+func NewWsAlchemyProvider(config AlchemyConfig) types.IAlchemyProvider {
+	return &WsAlchemyProvider{config: config}
+}
+
+func (provider *WsAlchemyProvider) SetEth(eth types.EtherApi) {
+	provider.eth = eth
+}
+
+func (provider *WsAlchemyProvider) Eth() types.EtherApi {
+	return provider.eth
+}
+
+func (provider *WsAlchemyProvider) CustomHeaders() []http.Header {
+	return provider.config.customHeaders
+}
+
+func (provider *WsAlchemyProvider) Network() types.Network {
+	return provider.config.network
+}
+
+// Send dispatches a single JSON-RPC call over the ws socket, mirroring the
+// HTTP provider's contract: it returns the raw result (map/slice/string) or
+// ErrResultIsNil when the node answers with a null result.
+func (provider *WsAlchemyProvider) Send(method string, params types.RequestArgs) (any, error) {
+	client, err := provider.rpcClient()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := provider.requestContext()
+	defer cancel()
+
+	var result any
+	if err := client.CallContext(ctx, &result, method, params...); err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, constant.ErrResultIsNil
+	}
+	return result, nil
+}
+
+// Subscribe opens an eth_subscribe stream over the ws socket. The returned
+// *rpc.ClientSubscription satisfies ethereum.Subscription.
+func (provider *WsAlchemyProvider) Subscribe(ctx context.Context, channel any, params ...any) (ethereum.Subscription, error) {
+	client, err := provider.rpcClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.EthSubscribe(ctx, channel, params...)
+}
+
+// rpcClient establishes (or reuses) Ether's persistent ws client and returns the
+// underlying geth rpc.Client used for both calls and subscriptions.
+func (provider *WsAlchemyProvider) rpcClient() (*rpc.Client, error) {
+	if provider.eth == nil {
+		return nil, constant.ErrProviderEthNotSet
+	}
+	if err := provider.eth.SetEthClient(); err != nil {
+		return nil, err
+	}
+	client, ok := provider.eth.Client().(*ethclient.Client)
+	if !ok {
+		return nil, constant.ErrUnSupportSimulatedMethod
+	}
+	return client.Client(), nil
+}
+
+func (provider *WsAlchemyProvider) requestContext() (context.Context, context.CancelFunc) {
+	if provider.config.requestTimeout > 0 {
+		return context.WithTimeout(context.Background(), provider.config.requestTimeout)
+	}
+	return context.WithCancel(context.Background())
+}

--- a/gas/ws_provider_test.go
+++ b/gas/ws_provider_test.go
@@ -1,0 +1,130 @@
+package gas
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/poteto-go/go-alchemy-sdk/constant"
+	"github.com/poteto-go/go-alchemy-sdk/ether"
+	"github.com/poteto-go/go-alchemy-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wsTestAPI is a fake "eth" namespace served over the in-process websocket rpc
+// server. It answers eth_blockNumber (a plain call) and eth_subscribe("ticks")
+// (a push subscription) so the ws provider can do real round-trips.
+type wsTestAPI struct{}
+
+func (wsTestAPI) BlockNumber() hexutil.Uint64 { return hexutil.Uint64(0x42) }
+
+func (wsTestAPI) Ticks(ctx context.Context) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return nil, rpc.ErrNotificationsUnsupported
+	}
+
+	sub := notifier.CreateSubscription()
+	go func() {
+		notifier.Notify(sub.ID, "0x1")
+	}()
+	return sub, nil
+}
+
+// newWsProviderForTest stands up an in-process JSON-RPC ws server and returns a
+// WsAlchemyProvider whose Ether is dialed at that server. The cleanup closes the
+// server and the persistent ws socket.
+func newWsProviderForTest(t *testing.T) *WsAlchemyProvider {
+	t.Helper()
+
+	srv := rpc.NewServer()
+	require.NoError(t, srv.RegisterName("eth", wsTestAPI{}))
+
+	ts := httptest.NewServer(srv.WebsocketHandler([]string{"*"}))
+	// httptest serves over http://; the rpc client dials ws:// on the same host.
+	wsUrl := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	config, err := NewAlchemyConfig(AlchemySetting{
+		ApiKey:       "hoge",
+		Network:      "fuga",
+		UseWebsocket: true,
+	})
+	require.NoError(t, err)
+
+	provider := NewWsAlchemyProvider(config).(*WsAlchemyProvider)
+	eth := ether.NewEtherApi(
+		provider,
+		// override the derived alchemy endpoint with the in-process ws url.
+		ether.NewEtherApiConfig(wsUrl, 0, 2*time.Second, &types.DefaultBackoffConfig, []http.Header{}, nil, 5<<20, nil),
+	)
+	provider.SetEth(eth)
+
+	t.Cleanup(func() {
+		eth.Shutdown()
+		ts.Close()
+		srv.Stop()
+	})
+	return provider
+}
+
+func TestNewWsAlchemyProvider(t *testing.T) {
+	customHeaders := []http.Header{{"hello": []string{"world"}}}
+	config, err := NewAlchemyConfig(AlchemySetting{
+		ApiKey:        "hoge",
+		Network:       "fuga",
+		UseWebsocket:  true,
+		CustomHeaders: customHeaders,
+	})
+	require.NoError(t, err)
+
+	provider := NewWsAlchemyProvider(config).(*WsAlchemyProvider)
+
+	assert.Equal(t, types.Network("fuga"), provider.Network())
+	assert.Equal(t, customHeaders, provider.CustomHeaders())
+}
+
+func TestWsAlchemyProvider_Send(t *testing.T) {
+	t.Run("routes the call over the ws socket", func(t *testing.T) {
+		provider := newWsProviderForTest(t)
+
+		result, err := provider.Send("eth_blockNumber", types.RequestArgs{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "0x42", result)
+	})
+
+	t.Run("returns error if eth client is not set", func(t *testing.T) {
+		config, _ := NewAlchemyConfig(AlchemySetting{ApiKey: "k", Network: "n", UseWebsocket: true})
+		provider := NewWsAlchemyProvider(config).(*WsAlchemyProvider)
+
+		_, err := provider.Send("eth_blockNumber", types.RequestArgs{})
+		assert.ErrorIs(t, err, constant.ErrProviderEthNotSet)
+	})
+}
+
+func TestWsAlchemyProvider_Subscribe(t *testing.T) {
+	provider := newWsProviderForTest(t)
+
+	ch := make(chan string, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	sub, err := provider.Subscribe(ctx, ch, "ticks")
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	select {
+	case got := <-ch:
+		assert.Equal(t, "0x1", got)
+	case err := <-sub.Err():
+		t.Fatalf("subscription errored: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for subscription notification")
+	}
+}

--- a/gas/ws_provider_test.go
+++ b/gas/ws_provider_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	gethCoreTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient/simulated"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/poteto-go/go-alchemy-sdk/constant"
 	"github.com/poteto-go/go-alchemy-sdk/ether"
@@ -23,6 +25,9 @@ import (
 type wsTestAPI struct{}
 
 func (wsTestAPI) BlockNumber() hexutil.Uint64 { return hexutil.Uint64(0x42) }
+
+// Null answers eth_null with a JSON null result, to exercise the ErrResultIsNil path.
+func (wsTestAPI) Null() *hexutil.Uint64 { return nil }
 
 func (wsTestAPI) Ticks(ctx context.Context) (*rpc.Subscription, error) {
 	notifier, supported := rpc.NotifierFromContext(ctx)
@@ -89,6 +94,11 @@ func TestNewWsAlchemyProvider(t *testing.T) {
 	assert.Equal(t, customHeaders, provider.CustomHeaders())
 }
 
+func TestWsAlchemyProvider_Eth(t *testing.T) {
+	provider := newWsProviderForTest(t)
+	assert.NotNil(t, provider.Eth())
+}
+
 func TestWsAlchemyProvider_Send(t *testing.T) {
 	t.Run("routes the call over the ws socket", func(t *testing.T) {
 		provider := newWsProviderForTest(t)
@@ -99,6 +109,32 @@ func TestWsAlchemyProvider_Send(t *testing.T) {
 		assert.Equal(t, "0x42", result)
 	})
 
+	t.Run("works without a request timeout (no deadline branch)", func(t *testing.T) {
+		provider := newWsProviderForTest(t)
+		// drive the requestContext WithCancel branch: a 0 timeout means no deadline.
+		provider.config.requestTimeout = 0
+
+		result, err := provider.Send("eth_blockNumber", types.RequestArgs{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "0x42", result)
+	})
+
+	t.Run("returns ErrResultIsNil when the node answers null", func(t *testing.T) {
+		provider := newWsProviderForTest(t)
+
+		_, err := provider.Send("eth_null", types.RequestArgs{})
+		assert.ErrorIs(t, err, constant.ErrResultIsNil)
+	})
+
+	t.Run("propagates a CallContext error", func(t *testing.T) {
+		provider := newWsProviderForTest(t)
+
+		// the in-process server does not expose eth_doesNotExist -> rpc error.
+		_, err := provider.Send("eth_doesNotExist", types.RequestArgs{})
+		assert.Error(t, err)
+	})
+
 	t.Run("returns error if eth client is not set", func(t *testing.T) {
 		config, _ := NewAlchemyConfig(AlchemySetting{ApiKey: "k", Network: "n", UseWebsocket: true})
 		provider := NewWsAlchemyProvider(config).(*WsAlchemyProvider)
@@ -106,9 +142,41 @@ func TestWsAlchemyProvider_Send(t *testing.T) {
 		_, err := provider.Send("eth_blockNumber", types.RequestArgs{})
 		assert.ErrorIs(t, err, constant.ErrProviderEthNotSet)
 	})
+
+	t.Run("returns ErrUnSupportSimulatedMethod over a simulated backend", func(t *testing.T) {
+		backend := simulated.NewBackend(gethCoreTypes.GenesisAlloc{})
+		defer backend.Close()
+
+		config, _ := NewAlchemyConfig(AlchemySetting{ApiKey: "k", Network: "n", UseWebsocket: true})
+		provider := NewWsAlchemyProvider(config).(*WsAlchemyProvider)
+		provider.SetEth(ether.NewSimulatedApi(backend))
+
+		_, err := provider.Send("eth_blockNumber", types.RequestArgs{})
+		assert.ErrorIs(t, err, constant.ErrUnSupportSimulatedMethod)
+	})
+
+	t.Run("propagates a SetEthClient dial error", func(t *testing.T) {
+		config, _ := NewAlchemyConfig(AlchemySetting{ApiKey: "k", Network: "n", UseWebsocket: true})
+		provider := NewWsAlchemyProvider(config).(*WsAlchemyProvider)
+		// nothing listens on port 1 -> the ws dial inside SetEthClient fails.
+		provider.SetEth(ether.NewEtherApi(provider, ether.NewEtherApiConfig(
+			"ws://127.0.0.1:1", 0, 500*time.Millisecond, &types.DefaultBackoffConfig, []http.Header{}, nil, 5<<20, nil,
+		)))
+
+		_, err := provider.Send("eth_blockNumber", types.RequestArgs{})
+		assert.Error(t, err)
+	})
 }
 
 func TestWsAlchemyProvider_Subscribe(t *testing.T) {
+	t.Run("returns error if eth client is not set", func(t *testing.T) {
+		config, _ := NewAlchemyConfig(AlchemySetting{ApiKey: "k", Network: "n", UseWebsocket: true})
+		provider := NewWsAlchemyProvider(config).(*WsAlchemyProvider)
+
+		_, err := provider.Subscribe(context.Background(), make(chan string), "ticks")
+		assert.ErrorIs(t, err, constant.ErrProviderEthNotSet)
+	})
+
 	provider := newWsProviderForTest(t)
 
 	ch := make(chan string, 1)

--- a/types/alchemy_provider.go
+++ b/types/alchemy_provider.go
@@ -1,8 +1,11 @@
 package types
 
 import (
+	"context"
 	"errors"
 	"net/http"
+
+	"github.com/ethereum/go-ethereum"
 )
 
 var ErrNoResultFound = errors.New("no result found")
@@ -38,6 +41,18 @@ type IAlchemyProvider interface {
 
 	/* Send raw transaction */
 	Send(method string, params RequestArgs) (any, error)
+}
+
+// ISubscribeProvider is the focused subscribe surface implemented only by the
+// ws provider. It is kept separate from IAlchemyProvider so HTTP providers (which
+// cannot push) are not forced to implement a subscribe path. The subscription
+// namespace type-asserts a provider to this interface to open eth_subscribe
+// streams over the persistent ws socket.
+type ISubscribeProvider interface {
+	// Subscribe opens an eth_subscribe stream. params[0] is the subscription
+	// name (e.g. "newHeads", "logs", "alchemy_minedTransactions"); notifications
+	// are delivered on channel until the returned subscription is unsubscribed.
+	Subscribe(ctx context.Context, channel any, params ...any) (ethereum.Subscription, error)
 }
 
 type AlchemyFetchHandler func(*http.Client, AlchemyRequest, []byte) (AlchemyResponse, error)


### PR DESCRIPTION
## Summary

Adds `gas/ws_provider.go` — a `WsAlchemyProvider` that routes JSON-RPC **and** `eth_subscribe` over the persistent ws `rpc.Client` owned by `Ether` (landed in #472), rather than dialing a second socket. This is the provider-layer counterpart of the ether-side WS transport and the prerequisite for the subscription namespace.

Closes #475.

## What changed

- **`gas/ws_provider.go`** — `WsAlchemyProvider` implementing `IAlchemyProvider`:
  - `Send(method, params)` now works over a ws `Alchemy`. It reuses Ether's persistent ws client (`SetEthClient` → `Client().(*ethclient.Client).Client()`) and dispatches via `rpc.Client.CallContext`, mirroring the HTTP provider's contract (raw result, `ErrResultIsNil` on null). This **removes the prior "Send-based methods are HTTP-only" caveat**.
  - `Subscribe(ctx, channel, params...)` exposes `eth_subscribe`, returning geth's `ethereum.Subscription`.
- **`types.ISubscribeProvider`** — a focused subscribe interface, kept **separate** from `IAlchemyProvider` so HTTP providers aren't forced to implement a push path. The upcoming subscription namespace type-asserts to this.
- **`NewAlchemy` wiring** — selects the provider by resolved url scheme (`ws`/`wss` → ws provider, else HTTP) via `AlchemyConfig.isWebSocket()`, mirroring `Ether.isWebSocket()`.

## Open question (resolved)

The issue asked whether `Send` should go over ws or stay HTTP. This PR **unifies transport**: a ws `Alchemy` serves calls and subscriptions over one socket, so users no longer need two instances. No second dial is opened — the existing persistent client is reused.

## Tests

- `gas/ws_provider_test.go` — in-process JSON-RPC ws server (per #472) covering `Send` + `Subscribe` round-trips and the not-set-eth error path.
- `gas/alchemy_test.go` — provider selection by scheme.
- `e2e/ws_rpc_test.go` — now exercises a `Send`-based method (`GetBalance`) over the ws socket against anvil.

Docs: `setting/alchemySetting.md` "HTTP-only methods" → "Unified transport".

## Related

- #472 — ether-side WS transport (persistent client, `Shutdown`).
- Follow-up: subscription namespace consumes `ISubscribeProvider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
