### PR TITLE
feat: add a WebSocket test double to alchemymock (subscription mocking)

### DIFF
--- a/alchemymock/ws_mock.go
+++ b/alchemymock/ws_mock.go
@@ -1,0 +1,128 @@
+package alchemymock
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// AlchemyWsMock is an in-process WebSocket test double for subscription-based
+// Alchemy code (eth_subscribe newHeads / logs / pending / alchemy_minedTransactions).
+//
+// Unlike AlchemyHttpMock — which is built on jarcoal/httpmock and intercepts at
+// the http.RoundTripper layer (one request -> one response) — geth dials ws via
+// gorilla/websocket's raw TCP + HTTP Upgrade and a subscription is one request
+// followed by an unbounded server-pushed stream. Neither fits the responder
+// model, so this is a separate implementation backed by a real geth rpc.Server
+// over httptest. Push canned notifications with the Emit* helpers.
+//
+// Example:
+//
+//	mock := alchemymock.NewAlchemyWsMock(t)
+//	defer mock.Close()
+//
+//	a, _ := gas.NewAlchemy(gas.AlchemySetting{
+//		PrivateNetworkConfig: gas.PrivateNetworkConfig{Url: mock.URL()},
+//	})
+//	sub := a.GetProvider().(types.ISubscribeProvider)
+//	ch := make(chan *gethTypes.Header)
+//	sub.Subscribe(ctx, ch, "newHeads")
+//	mock.EmitNewHeads(headers...)
+type AlchemyWsMock struct {
+	server *httptest.Server
+	rpcSrv *rpc.Server
+	api    *wsEthAPI
+}
+
+// NewAlchemyWsMock stands up a geth rpc.Server exposing a fake "eth" namespace
+// over a websocket httptest server. Pair it with a ws-scheme Alchemy setting
+// pointed at URL(). Call Close (defer recommended) to tear it down.
+func NewAlchemyWsMock(t testing.TB) *AlchemyWsMock {
+	api := &wsEthAPI{subs: make(map[rpc.ID]*rpc.Notifier)}
+
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("eth", api); err != nil {
+		t.Fatal(err)
+	}
+
+	// httptest serves over http://; geth's rpc client dials ws:// on the same host.
+	server := httptest.NewServer(srv.WebsocketHandler([]string{"*"}))
+
+	return &AlchemyWsMock{server: server, rpcSrv: srv, api: api}
+}
+
+// URL returns the ws:// endpoint to feed an Alchemy ws setting.
+func (m *AlchemyWsMock) URL() string {
+	return "ws" + strings.TrimPrefix(m.server.URL, "http")
+}
+
+// Close stops the websocket server and any active subscriptions. Safe to call
+// more than once: both httptest.Server.Close and rpc.Server.Stop are idempotent.
+func (m *AlchemyWsMock) Close() {
+	m.server.Close()
+	m.rpcSrv.Stop()
+}
+
+// EmitNewHeads pushes the given headers to every active newHeads subscriber, in
+// order. Call it after the subscription is established (i.e. after Subscribe has
+// returned); with no subscribers it is a no-op.
+func (m *AlchemyWsMock) EmitNewHeads(headers ...*gethTypes.Header) {
+	for _, h := range headers {
+		m.api.emit(h)
+	}
+}
+
+// wsEthAPI is the fake "eth" namespace served over the in-process ws rpc server.
+// Its subscription methods register active subscribers (keyed by subscription id)
+// that the Emit* helpers fan notifications out to.
+type wsEthAPI struct {
+	mu   sync.Mutex
+	subs map[rpc.ID]*rpc.Notifier
+}
+
+// NewHeads implements eth_subscribe("newHeads"). geth derives the subscription
+// name from the method name, so this is reachable via EthSubscribe(ctx, ch,
+// "newHeads"). It registers the subscriber and unregisters it when the client
+// unsubscribes or the connection drops.
+func (api *wsEthAPI) NewHeads(ctx context.Context) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return nil, rpc.ErrNotificationsUnsupported
+	}
+
+	rpcSub := notifier.CreateSubscription()
+	api.add(rpcSub.ID, notifier)
+
+	go func() {
+		<-rpcSub.Err() // fires on Unsubscribe or connection drop
+		api.remove(rpcSub.ID)
+	}()
+
+	return rpcSub, nil
+}
+
+func (api *wsEthAPI) add(id rpc.ID, notifier *rpc.Notifier) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	api.subs[id] = notifier
+}
+
+func (api *wsEthAPI) remove(id rpc.ID) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	delete(api.subs, id)
+}
+
+// emit fans a single notification out to every active subscriber.
+func (api *wsEthAPI) emit(data any) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	for id, notifier := range api.subs {
+		notifier.Notify(id, data)
+	}
+}

--- a/alchemymock/ws_mock.go
+++ b/alchemymock/ws_mock.go
@@ -123,6 +123,8 @@ func (api *wsEthAPI) emit(data any) {
 	api.mu.Lock()
 	defer api.mu.Unlock()
 	for id, notifier := range api.subs {
-		notifier.Notify(id, data)
+		// Notify errors only when the ws connection is already gone; the
+		// blocked NewHeads goroutine will remove the dead sub via rpcSub.Err().
+		_ = notifier.Notify(id, data)
 	}
 }

--- a/alchemymock/ws_mock_test.go
+++ b/alchemymock/ws_mock_test.go
@@ -1,0 +1,91 @@
+package alchemymock_test
+
+import (
+	"context"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/poteto-go/go-alchemy-sdk/alchemymock"
+	"github.com/poteto-go/go-alchemy-sdk/gas"
+	"github.com/poteto-go/go-alchemy-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newWsAlchemyForMock builds a ws Alchemy whose geth client dials the in-process
+// mock. A ws-scheme private-network url selects the WsAlchemyProvider, so the
+// subscribe path is exercised exactly as a real ws Alchemy would.
+func newWsAlchemyForMock(t *testing.T, url string) gas.Alchemy {
+	t.Helper()
+	a, err := gas.NewAlchemy(gas.AlchemySetting{
+		PrivateNetworkConfig: gas.PrivateNetworkConfig{Url: url},
+	})
+	require.NoError(t, err)
+	return a
+}
+
+func TestNewAlchemyWsMock(t *testing.T) {
+	t.Run("URL returns a ws:// endpoint", func(t *testing.T) {
+		mock := alchemymock.NewAlchemyWsMock(t)
+		defer mock.Close()
+
+		assert.True(t, strings.HasPrefix(mock.URL(), "ws://"), "url should be ws://: %s", mock.URL())
+	})
+
+	t.Run("Close is safe to call twice", func(t *testing.T) {
+		mock := alchemymock.NewAlchemyWsMock(t)
+		mock.Close()
+		assert.NotPanics(t, func() { mock.Close() })
+	})
+}
+
+func TestAlchemyWsMock_EmitNewHeads(t *testing.T) {
+	t.Run("emitted headers are pushed to a newHeads subscriber", func(t *testing.T) {
+		// Arrange
+		mock := alchemymock.NewAlchemyWsMock(t)
+		defer mock.Close()
+
+		wsAlchemy := newWsAlchemyForMock(t, mock.URL())
+		defer wsAlchemy.GetProvider().Eth().Shutdown()
+
+		sub, ok := wsAlchemy.GetProvider().(types.ISubscribeProvider)
+		require.True(t, ok, "ws provider must implement ISubscribeProvider")
+
+		ch := make(chan *gethTypes.Header, 4)
+		subscription, err := sub.Subscribe(context.Background(), ch, "newHeads")
+		require.NoError(t, err)
+		defer subscription.Unsubscribe()
+
+		// Act: push two canned heads after the subscription is established.
+		// newHeads notifications carry full headers; geth's Header.UnmarshalJSON
+		// requires difficulty (and number), so both are set.
+		mock.EmitNewHeads(
+			&gethTypes.Header{Number: big.NewInt(0x10), Difficulty: big.NewInt(0)},
+			&gethTypes.Header{Number: big.NewInt(0x11), Difficulty: big.NewInt(0)},
+		)
+
+		// Assert: they arrive on the subscriber channel in order.
+		for _, want := range []int64{0x10, 0x11} {
+			select {
+			case got := <-ch:
+				assert.Equal(t, want, got.Number.Int64())
+			case err := <-subscription.Err():
+				t.Fatalf("subscription errored: %v", err)
+			case <-time.After(2 * time.Second):
+				t.Fatalf("timed out waiting for head 0x%x", want)
+			}
+		}
+	})
+
+	t.Run("EmitNewHeads with no subscribers is a no-op", func(t *testing.T) {
+		mock := alchemymock.NewAlchemyWsMock(t)
+		defer mock.Close()
+
+		assert.NotPanics(t, func() {
+			mock.EmitNewHeads(&gethTypes.Header{Number: big.NewInt(1)})
+		})
+	})
+}

--- a/docs/docs/development/Mock.md
+++ b/docs/docs/development/Mock.md
@@ -31,6 +31,40 @@ func TestSomething(t *testing.T) {
 }
 ```
 
+## WebSocket subscriptions
+
+`NewAlchemyHttpMock` mocks one request → one response over HTTP, which cannot model
+a subscription (one `eth_subscribe` request followed by a server-pushed stream).
+For subscription-based code, use `NewAlchemyWsMock`: it stands up a real in-process
+WebSocket JSON-RPC server and lets you push canned notifications with the `Emit*`
+helpers.
+
+```go
+func TestSubscription(t *testing.T) {
+	mock := alchemymock.NewAlchemyWsMock(t)
+	defer mock.Close()
+
+	// A ws-scheme url selects the WebSocket provider.
+	alchemy, _ := gas.NewAlchemy(gas.AlchemySetting{
+		PrivateNetworkConfig: gas.PrivateNetworkConfig{Url: mock.URL()},
+	})
+	defer alchemy.GetProvider().Eth().Shutdown()
+
+	sub := alchemy.GetProvider().(types.ISubscribeProvider)
+	ch := make(chan *gethTypes.Header, 4)
+	subscription, _ := sub.Subscribe(context.Background(), ch, "newHeads")
+	defer subscription.Unsubscribe()
+
+	// Push canned heads after the subscription is established.
+	mock.EmitNewHeads(
+		&gethTypes.Header{Number: big.NewInt(0x10), Difficulty: big.NewInt(0)},
+	)
+
+	head := <-ch
+	assert.Equal(t, int64(0x10), head.Number.Int64())
+}
+```
+
 ## Detail
 
 If you want to test your code without making changes to a public chain, you can easily do so with mocks.


### PR DESCRIPTION
## Summary

Closes #473. Adds `AlchemyWsMock`, a reusable WebSocket test double to the `alchemymock` package so subscription-based code (`eth_subscribe`) can be unit-tested with the same ergonomics as the existing httpmock-based `AlchemyHttpMock`.

`AlchemyHttpMock` is built on `jarcoal/httpmock`, which intercepts at the `http.RoundTripper` layer and models one request → one response — neither fits WebSocket (geth dials ws via raw TCP + HTTP Upgrade, and a subscription is one request followed by an unbounded server-pushed stream). So this is a **separate implementation** backed by a real in-process `rpc.Server` + `WebsocketHandler` over `httptest`, living alongside the httpmock-based mock.

## What's included

- `NewAlchemyWsMock(t)` / `URL()` / `Close()` — stands up the ws JSON-RPC server, returns the `ws://` endpoint, tears down (idempotent).
- Fake `eth` subscription API (`newHeads` first; logs / pending / `alchemy_minedTransactions` are follow-ups) with an external `EmitNewHeads(headers...)` push helper that fans canned notifications out to active subscribers.
- Self-tests that drive the **real** `WsAlchemyProvider` over the mock socket (ws-scheme url → ws provider), proving the full subscribe path end-to-end.
- Docs: a *WebSocket subscriptions* section in `docs/docs/development/Mock.md`.

## Usage

```go
mock := alchemymock.NewAlchemyWsMock(t)
defer mock.Close()

a, _ := gas.NewAlchemy(gas.AlchemySetting{
    PrivateNetworkConfig: gas.PrivateNetworkConfig{Url: mock.URL()},
})
sub := a.GetProvider().(types.ISubscribeProvider)
ch := make(chan *gethTypes.Header, 4)
sub.Subscribe(ctx, ch, "newHeads")

mock.EmitNewHeads(headers...) // pushes notifications to subscribers
```

## Testing

- `go test ./alchemymock/ -race` (incl. repeated runs for flake-checking) ✅
- Full non-e2e suite green ✅
- Reviewed via `/simplify`: dropped a redundant `activeSub` struct (id duplicated the map key → `map[rpc.ID]*rpc.Notifier`) and an unnecessary `sync.Once` in `Close` (both underlying teardowns are already idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)