### PR TITLE
feat: add AlchemyWsMock — full WebSocket test double for calls and subscriptions

### DIFF
--- a/alchemymock/ws_mock.go
+++ b/alchemymock/ws_mock.go
@@ -1,0 +1,299 @@
+package alchemymock
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/gorilla/websocket"
+)
+
+// wsRPCRequest is a single JSON-RPC 2.0 request frame.
+type wsRPCRequest struct {
+	JSONRPC string            `json:"jsonrpc"`
+	ID      json.RawMessage   `json:"id"`
+	Method  string            `json:"method"`
+	Params  []json.RawMessage `json:"params"`
+}
+
+type wsRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *wsRPCError     `json:"error,omitempty"`
+}
+
+type wsRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type wsSubNotification struct {
+	JSONRPC string           `json:"jsonrpc"`
+	Method  string           `json:"method"`
+	Params  wsSubNotifParams `json:"params"`
+}
+
+type wsSubNotifParams struct {
+	Subscription string          `json:"subscription"`
+	Result       json.RawMessage `json:"result"`
+}
+
+// wsMockConn wraps a single WebSocket connection and its active subscriptions.
+type wsMockConn struct {
+	mu      sync.Mutex
+	conn    *websocket.Conn
+	subKind map[string]string // subscription ID -> kind (e.g. "newHeads")
+}
+
+// writeJSON serialises v and sends it as a single text frame.
+// It is safe to call from multiple goroutines.
+func (c *wsMockConn) writeJSON(v any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.conn.WriteJSON(v)
+}
+
+var wsUpgrader = websocket.Upgrader{
+	CheckOrigin: func(*http.Request) bool { return true },
+}
+
+// AlchemyWsMock is an in-process WebSocket JSON-RPC test double that supports
+// both regular calls (via RegisterResponderOnce) and push subscriptions
+// (via EmitNewHeads and Emit).
+//
+// Unlike AlchemyHttpMock — which hooks into the http.RoundTripper layer — this
+// mock runs a real httptest WebSocket server because geth's rpc.Client dials a
+// real socket; there is no WS equivalent of httpmock's transport intercept.
+//
+// Usage:
+//
+//	mock := alchemymock.NewAlchemyWsMock(t)
+//	a, _ := gas.NewAlchemy(gas.AlchemySetting{
+//	    PrivateNetworkConfig: gas.PrivateNetworkConfig{Url: mock.URL()},
+//	})
+//	mock.RegisterResponderOnce("eth_blockNumber", `{"jsonrpc":"2.0","id":1,"result":"0x42"}`)
+//	bn, _ := a.Core.GetBlockNumber() // -> 66
+type AlchemyWsMock struct {
+	t          testing.TB
+	ts         *httptest.Server
+	mu         sync.Mutex
+	responders map[string][]json.RawMessage // method -> queued "result" values
+	conns      []*wsMockConn
+	nextSubID  atomic.Uint64
+	handlers   sync.WaitGroup // tracks active serveWS goroutines
+}
+
+// NewAlchemyWsMock creates a new in-process WebSocket JSON-RPC mock server and
+// registers a cleanup that shuts it down when the test ends.
+func NewAlchemyWsMock(t testing.TB) *AlchemyWsMock {
+	m := &AlchemyWsMock{
+		t:          t,
+		responders: make(map[string][]json.RawMessage),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", m.serveWS)
+	m.ts = httptest.NewServer(mux)
+	t.Cleanup(m.Close)
+	return m
+}
+
+// URL returns the ws:// endpoint of the mock server.
+// Pass it as gas.PrivateNetworkConfig.Url to route an Alchemy instance through
+// this mock.
+func (m *AlchemyWsMock) URL() string {
+	return "ws" + m.ts.URL[len("http"):]
+}
+
+// Close shuts down the mock server and waits for active handler goroutines to
+// finish. It is idempotent and called automatically by the test cleanup
+// registered in NewAlchemyWsMock.
+func (m *AlchemyWsMock) Close() {
+	m.ts.Close()
+	// http.Server.Close does not close hijacked WebSocket connections.
+	// Explicitly close them to unblock the ReadMessage loops in serveWS goroutines.
+	m.mu.Lock()
+	conns := make([]*wsMockConn, len(m.conns))
+	copy(conns, m.conns)
+	m.mu.Unlock()
+	for _, mc := range conns {
+		mc.conn.Close()
+	}
+	m.handlers.Wait()
+}
+
+// RegisterResponderOnce queues response as the next JSON-RPC reply for method.
+// The format mirrors AlchemyHttpMock.RegisterResponderOnce: pass the full
+// JSON-RPC envelope, e.g.:
+//
+//	mock.RegisterResponderOnce("eth_blockNumber", `{"jsonrpc":"2.0","id":1,"result":"0x42"}`)
+//
+// The mock extracts the "result" field and re-uses the actual request's id when
+// sending the response, so the id in response is ignored.
+// It calls t.Fatalf if response is not a valid JSON-RPC envelope with a "result" field.
+func (m *AlchemyWsMock) RegisterResponderOnce(method, response string) {
+	var envelope struct {
+		Result json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(response), &envelope); err != nil || len(envelope.Result) == 0 {
+		m.t.Fatalf("AlchemyWsMock.RegisterResponderOnce: %q is not a valid JSON-RPC envelope with a result field", response)
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.responders[method] = append(m.responders[method], envelope.Result)
+}
+
+// Emit pushes a raw subscription notification of the given kind to all
+// connections that hold an active subscription of that kind.
+// Use this to push any subscription type not covered by a typed helper:
+//
+//	mock.Emit("logs", rawLogsJSON)
+func (m *AlchemyWsMock) Emit(kind string, result json.RawMessage) {
+	m.mu.Lock()
+	conns := make([]*wsMockConn, len(m.conns))
+	copy(conns, m.conns)
+	m.mu.Unlock()
+
+	for _, mc := range conns {
+		mc.mu.Lock()
+		var matchIDs []string
+		for subID, k := range mc.subKind {
+			if k == kind {
+				matchIDs = append(matchIDs, subID)
+			}
+		}
+		mc.mu.Unlock()
+
+		for _, subID := range matchIDs {
+			_ = mc.writeJSON(wsSubNotification{
+				JSONRPC: "2.0",
+				Method:  "eth_subscription",
+				Params:  wsSubNotifParams{Subscription: subID, Result: result},
+			})
+		}
+	}
+}
+
+// EmitNewHeads pushes a newHeads subscription notification for each header to
+// all connections that have an active newHeads subscription.
+func (m *AlchemyWsMock) EmitNewHeads(headers ...*gethTypes.Header) {
+	for _, h := range headers {
+		data, err := json.Marshal(h)
+		if err != nil {
+			m.t.Logf("AlchemyWsMock: marshal header: %v", err)
+			continue
+		}
+		m.Emit("newHeads", data)
+	}
+}
+
+func (m *AlchemyWsMock) serveWS(w http.ResponseWriter, r *http.Request) {
+	m.handlers.Add(1)
+	defer m.handlers.Done()
+
+	conn, err := wsUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		m.t.Logf("AlchemyWsMock: upgrade: %v", err)
+		return
+	}
+
+	mc := &wsMockConn{conn: conn, subKind: make(map[string]string)}
+
+	m.mu.Lock()
+	m.conns = append(m.conns, mc)
+	m.mu.Unlock()
+
+	defer func() {
+		conn.Close()
+		m.mu.Lock()
+		for i, c := range m.conns {
+			if c == mc {
+				m.conns = append(m.conns[:i], m.conns[i+1:]...)
+				break
+			}
+		}
+		m.mu.Unlock()
+	}()
+
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+
+		var req wsRPCRequest
+		if err := json.Unmarshal(msg, &req); err != nil {
+			m.t.Logf("AlchemyWsMock: bad frame: %v", err)
+			continue
+		}
+
+		switch req.Method {
+		case "eth_subscribe":
+			m.handleSubscribe(mc, &req)
+		case "eth_unsubscribe":
+			m.handleUnsubscribe(mc, &req)
+		default:
+			m.handleCall(mc, &req)
+		}
+	}
+}
+
+func (m *AlchemyWsMock) newSubID() string {
+	n := m.nextSubID.Add(1)
+	return fmt.Sprintf("0x%x", n)
+}
+
+func (m *AlchemyWsMock) handleSubscribe(mc *wsMockConn, req *wsRPCRequest) {
+	kind := "unknown"
+	if len(req.Params) > 0 {
+		_ = json.Unmarshal(req.Params[0], &kind)
+	}
+
+	subID := m.newSubID()
+	subIDJSON, _ := json.Marshal(subID)
+
+	mc.mu.Lock()
+	mc.subKind[subID] = kind
+	mc.mu.Unlock()
+
+	_ = mc.writeJSON(wsRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: subIDJSON})
+}
+
+func (m *AlchemyWsMock) handleUnsubscribe(mc *wsMockConn, req *wsRPCRequest) {
+	var subID string
+	if len(req.Params) > 0 {
+		_ = json.Unmarshal(req.Params[0], &subID)
+	}
+
+	mc.mu.Lock()
+	delete(mc.subKind, subID)
+	mc.mu.Unlock()
+
+	_ = mc.writeJSON(wsRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: json.RawMessage("true")})
+}
+
+func (m *AlchemyWsMock) handleCall(mc *wsMockConn, req *wsRPCRequest) {
+	m.mu.Lock()
+	var result json.RawMessage
+	if results := m.responders[req.Method]; len(results) > 0 {
+		result = results[0]
+		m.responders[req.Method] = results[1:]
+	}
+	m.mu.Unlock()
+
+	if result != nil {
+		_ = mc.writeJSON(wsRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: result})
+	} else {
+		_ = mc.writeJSON(wsRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &wsRPCError{Code: -32601, Message: fmt.Sprintf("method not mocked or no more mocks: %s", req.Method)},
+		})
+	}
+}

--- a/alchemymock/ws_mock.go
+++ b/alchemymock/ws_mock.go
@@ -11,6 +11,7 @@ import (
 
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/gorilla/websocket"
+	"github.com/poteto-go/go-alchemy-sdk/gas"
 )
 
 // wsRPCRequest is a single JSON-RPC 2.0 request frame.
@@ -73,14 +74,14 @@ var wsUpgrader = websocket.Upgrader{
 //
 // Usage:
 //
-//	mock := alchemymock.NewAlchemyWsMock(t)
-//	a, _ := gas.NewAlchemy(gas.AlchemySetting{
-//	    PrivateNetworkConfig: gas.PrivateNetworkConfig{Url: mock.URL()},
-//	})
+//	setting := gas.AlchemySetting{BackoffConfig: &types.BackoffConfig{MaxRetries: 0}}
+//	mock := alchemymock.NewAlchemyWsMock(setting, t)
+//	a, _ := mock.NewAlchemy()
 //	mock.RegisterResponderOnce("eth_blockNumber", `{"jsonrpc":"2.0","id":1,"result":"0x42"}`)
 //	bn, _ := a.Core.GetBlockNumber() // -> 66
 type AlchemyWsMock struct {
 	t          testing.TB
+	setting    gas.AlchemySetting
 	ts         *httptest.Server
 	mu         sync.Mutex
 	responders map[string][]json.RawMessage // method -> queued "result" values
@@ -91,9 +92,10 @@ type AlchemyWsMock struct {
 
 // NewAlchemyWsMock creates a new in-process WebSocket JSON-RPC mock server and
 // registers a cleanup that shuts it down when the test ends.
-func NewAlchemyWsMock(t testing.TB) *AlchemyWsMock {
+func NewAlchemyWsMock(setting gas.AlchemySetting, t testing.TB) *AlchemyWsMock {
 	m := &AlchemyWsMock{
 		t:          t,
+		setting:    setting,
 		responders: make(map[string][]json.RawMessage),
 	}
 	mux := http.NewServeMux()
@@ -101,6 +103,15 @@ func NewAlchemyWsMock(t testing.TB) *AlchemyWsMock {
 	m.ts = httptest.NewServer(mux)
 	t.Cleanup(m.Close)
 	return m
+}
+
+// NewAlchemy returns a gas.Alchemy wired to the mock's WebSocket endpoint,
+// using the setting passed to NewAlchemyWsMock with the URL overridden.
+// This mirrors how AlchemyHttpMock callers do gas.NewAlchemy(setting).
+func (m *AlchemyWsMock) NewAlchemy() (gas.Alchemy, error) {
+	s := m.setting
+	s.PrivateNetworkConfig = gas.PrivateNetworkConfig{Url: m.URL()}
+	return gas.NewAlchemy(s)
 }
 
 // URL returns the ws:// endpoint of the mock server.

--- a/alchemymock/ws_mock_test.go
+++ b/alchemymock/ws_mock_test.go
@@ -27,25 +27,20 @@ func newMinimalHeader(number int64) *gethTypes.Header {
 	}
 }
 
-func newWsAlchemyOnMock(t *testing.T, url string) gas.Alchemy {
-	t.Helper()
-	a, err := gas.NewAlchemy(gas.AlchemySetting{
-		PrivateNetworkConfig: gas.PrivateNetworkConfig{Url: url},
-		BackoffConfig:        &types.BackoffConfig{MaxRetries: 0},
-	})
-	require.NoError(t, err)
-	return a
+var wsMockSetting = gas.AlchemySetting{
+	BackoffConfig: &types.BackoffConfig{MaxRetries: 0},
 }
 
 func TestNewAlchemyWsMock(t *testing.T) {
-	mock := alchemymock.NewAlchemyWsMock(t)
+	mock := alchemymock.NewAlchemyWsMock(wsMockSetting, t)
 	assert.NotEmpty(t, mock.URL())
 }
 
 func TestAlchemyWsMock_RegisterResponderOnce(t *testing.T) {
 	t.Run("serves a regular call over the ws socket", func(t *testing.T) {
-		mock := alchemymock.NewAlchemyWsMock(t)
-		a := newWsAlchemyOnMock(t, mock.URL())
+		mock := alchemymock.NewAlchemyWsMock(wsMockSetting, t)
+		a, err := mock.NewAlchemy()
+		require.NoError(t, err)
 
 		mock.RegisterResponderOnce("eth_blockNumber", `{"jsonrpc":"2.0","id":1,"result":"0x10"}`)
 
@@ -56,17 +51,19 @@ func TestAlchemyWsMock_RegisterResponderOnce(t *testing.T) {
 	})
 
 	t.Run("returns error when method is not mocked", func(t *testing.T) {
-		mock := alchemymock.NewAlchemyWsMock(t)
-		a := newWsAlchemyOnMock(t, mock.URL())
+		mock := alchemymock.NewAlchemyWsMock(wsMockSetting, t)
+		a, err := mock.NewAlchemy()
+		require.NoError(t, err)
 
 		// No responder registered -> mock returns -32601.
-		_, err := a.Core.GetBlockNumber()
+		_, err = a.Core.GetBlockNumber()
 		assert.Error(t, err)
 	})
 
 	t.Run("serves responses in FIFO order for the same method", func(t *testing.T) {
-		mock := alchemymock.NewAlchemyWsMock(t)
-		a := newWsAlchemyOnMock(t, mock.URL())
+		mock := alchemymock.NewAlchemyWsMock(wsMockSetting, t)
+		a, err := mock.NewAlchemy()
+		require.NoError(t, err)
 
 		mock.RegisterResponderOnce("eth_blockNumber", `{"jsonrpc":"2.0","id":1,"result":"0x1"}`)
 		mock.RegisterResponderOnce("eth_blockNumber", `{"jsonrpc":"2.0","id":1,"result":"0x2"}`)
@@ -82,8 +79,9 @@ func TestAlchemyWsMock_RegisterResponderOnce(t *testing.T) {
 	})
 
 	t.Run("multiple different methods can be mocked independently", func(t *testing.T) {
-		mock := alchemymock.NewAlchemyWsMock(t)
-		a := newWsAlchemyOnMock(t, mock.URL())
+		mock := alchemymock.NewAlchemyWsMock(wsMockSetting, t)
+		a, err := mock.NewAlchemy()
+		require.NoError(t, err)
 
 		mock.RegisterResponderOnce("eth_blockNumber", `{"jsonrpc":"2.0","id":1,"result":"0x42"}`)
 		mock.RegisterResponderOnce("eth_gasPrice", `{"jsonrpc":"2.0","id":1,"result":"0x3b9aca00"}`)
@@ -99,8 +97,9 @@ func TestAlchemyWsMock_RegisterResponderOnce(t *testing.T) {
 }
 
 func TestAlchemyWsMock_EmitNewHeads(t *testing.T) {
-	mock := alchemymock.NewAlchemyWsMock(t)
-	a := newWsAlchemyOnMock(t, mock.URL())
+	mock := alchemymock.NewAlchemyWsMock(wsMockSetting, t)
+	a, err := mock.NewAlchemy()
+	require.NoError(t, err)
 
 	sub, ok := a.GetProvider().(types.ISubscribeProvider)
 	require.True(t, ok, "WS provider must implement ISubscribeProvider")
@@ -127,8 +126,9 @@ func TestAlchemyWsMock_EmitNewHeads(t *testing.T) {
 }
 
 func TestAlchemyWsMock_EmitNewHeads_MultipleHeaders(t *testing.T) {
-	mock := alchemymock.NewAlchemyWsMock(t)
-	a := newWsAlchemyOnMock(t, mock.URL())
+	mock := alchemymock.NewAlchemyWsMock(wsMockSetting, t)
+	a, err := mock.NewAlchemy()
+	require.NoError(t, err)
 
 	sub := a.GetProvider().(types.ISubscribeProvider)
 

--- a/alchemymock/ws_mock_test.go
+++ b/alchemymock/ws_mock_test.go
@@ -1,0 +1,157 @@
+package alchemymock_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/poteto-go/go-alchemy-sdk/alchemymock"
+	"github.com/poteto-go/go-alchemy-sdk/gas"
+	"github.com/poteto-go/go-alchemy-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMinimalHeader returns a gethTypes.Header with all JSON-required fields
+// populated so it survives a Header.UnmarshalJSON round-trip.
+func newMinimalHeader(number int64) *gethTypes.Header {
+	return &gethTypes.Header{
+		Number:      big.NewInt(number),
+		Difficulty:  big.NewInt(0),
+		Extra:       []byte{},
+		UncleHash:   gethTypes.EmptyUncleHash,
+		TxHash:      gethTypes.EmptyTxsHash,
+		ReceiptHash: gethTypes.EmptyReceiptsHash,
+	}
+}
+
+func newWsAlchemyOnMock(t *testing.T, url string) gas.Alchemy {
+	t.Helper()
+	a, err := gas.NewAlchemy(gas.AlchemySetting{
+		PrivateNetworkConfig: gas.PrivateNetworkConfig{Url: url},
+		BackoffConfig:        &types.BackoffConfig{MaxRetries: 0},
+	})
+	require.NoError(t, err)
+	return a
+}
+
+func TestNewAlchemyWsMock(t *testing.T) {
+	mock := alchemymock.NewAlchemyWsMock(t)
+	assert.NotEmpty(t, mock.URL())
+}
+
+func TestAlchemyWsMock_RegisterResponderOnce(t *testing.T) {
+	t.Run("serves a regular call over the ws socket", func(t *testing.T) {
+		mock := alchemymock.NewAlchemyWsMock(t)
+		a := newWsAlchemyOnMock(t, mock.URL())
+
+		mock.RegisterResponderOnce("eth_blockNumber", `{"jsonrpc":"2.0","id":1,"result":"0x10"}`)
+
+		bn, err := a.Core.GetBlockNumber()
+
+		require.NoError(t, err)
+		assert.Equal(t, uint64(16), bn)
+	})
+
+	t.Run("returns error when method is not mocked", func(t *testing.T) {
+		mock := alchemymock.NewAlchemyWsMock(t)
+		a := newWsAlchemyOnMock(t, mock.URL())
+
+		// No responder registered -> mock returns -32601.
+		_, err := a.Core.GetBlockNumber()
+		assert.Error(t, err)
+	})
+
+	t.Run("serves responses in FIFO order for the same method", func(t *testing.T) {
+		mock := alchemymock.NewAlchemyWsMock(t)
+		a := newWsAlchemyOnMock(t, mock.URL())
+
+		mock.RegisterResponderOnce("eth_blockNumber", `{"jsonrpc":"2.0","id":1,"result":"0x1"}`)
+		mock.RegisterResponderOnce("eth_blockNumber", `{"jsonrpc":"2.0","id":1,"result":"0x2"}`)
+
+		bn1, err1 := a.Core.GetBlockNumber()
+		require.NoError(t, err1)
+
+		bn2, err2 := a.Core.GetBlockNumber()
+		require.NoError(t, err2)
+
+		assert.Equal(t, uint64(1), bn1)
+		assert.Equal(t, uint64(2), bn2)
+	})
+
+	t.Run("multiple different methods can be mocked independently", func(t *testing.T) {
+		mock := alchemymock.NewAlchemyWsMock(t)
+		a := newWsAlchemyOnMock(t, mock.URL())
+
+		mock.RegisterResponderOnce("eth_blockNumber", `{"jsonrpc":"2.0","id":1,"result":"0x42"}`)
+		mock.RegisterResponderOnce("eth_gasPrice", `{"jsonrpc":"2.0","id":1,"result":"0x3b9aca00"}`)
+
+		bn, err := a.Core.GetBlockNumber()
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0x42), bn)
+
+		gp, err := a.Core.GetGasPrice()
+		require.NoError(t, err)
+		assert.Equal(t, big.NewInt(1_000_000_000), gp)
+	})
+}
+
+func TestAlchemyWsMock_EmitNewHeads(t *testing.T) {
+	mock := alchemymock.NewAlchemyWsMock(t)
+	a := newWsAlchemyOnMock(t, mock.URL())
+
+	sub, ok := a.GetProvider().(types.ISubscribeProvider)
+	require.True(t, ok, "WS provider must implement ISubscribeProvider")
+
+	ch := make(chan *gethTypes.Header, 4)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	subscription, err := sub.Subscribe(ctx, ch, "newHeads")
+	require.NoError(t, err)
+	defer subscription.Unsubscribe()
+
+	header := newMinimalHeader(0x42)
+	mock.EmitNewHeads(header)
+
+	select {
+	case got := <-ch:
+		assert.Equal(t, big.NewInt(0x42), got.Number)
+	case err := <-subscription.Err():
+		t.Fatalf("subscription error: %v", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for newHeads notification")
+	}
+}
+
+func TestAlchemyWsMock_EmitNewHeads_MultipleHeaders(t *testing.T) {
+	mock := alchemymock.NewAlchemyWsMock(t)
+	a := newWsAlchemyOnMock(t, mock.URL())
+
+	sub := a.GetProvider().(types.ISubscribeProvider)
+
+	ch := make(chan *gethTypes.Header, 4)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	subscription, err := sub.Subscribe(ctx, ch, "newHeads")
+	require.NoError(t, err)
+	defer subscription.Unsubscribe()
+
+	h1 := newMinimalHeader(1)
+	h2 := newMinimalHeader(2)
+	mock.EmitNewHeads(h1, h2)
+
+	for _, wantN := range []*big.Int{big.NewInt(1), big.NewInt(2)} {
+		select {
+		case got := <-ch:
+			assert.Equal(t, wantN, got.Number)
+		case err := <-subscription.Err():
+			t.Fatalf("subscription error: %v", err)
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for newHeads notification")
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ethereum/go-ethereum v1.17.3
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/gorilla/websocket v1.4.2
 	github.com/jarcoal/httpmock v1.4.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.53.0
@@ -49,7 +50,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grafana/pyroscope-go v1.2.7 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect


### PR DESCRIPTION
## Summary

Closes #473 (supersedes #479).

Adds `AlchemyWsMock`, a general-purpose in-process WebSocket JSON-RPC test double to the `alchemymock` package. Unlike PR #479 which only covered `eth_subscribe`, this mock handles **all** WS interactions — regular calls via `Send` and push subscriptions — using the same ergonomics as the existing `AlchemyHttpMock`.

### Why a custom server instead of geth's `rpc.Server`

`geth`'s `rpc.Server` requires statically registered Go methods, so only a fixed set of method names can be mocked. A custom in-process JSON-RPC server over gorilla/websocket (already an indirect dep) gives full dynamic dispatch.

### Public API

```go
mock := alchemymock.NewAlchemyWsMock(t)

a, _ := gas.NewAlchemy(gas.AlchemySetting{
    PrivateNetworkConfig: gas.PrivateNetworkConfig{Url: mock.URL()},
})

// Regular calls — same format as AlchemyHttpMock
mock.RegisterResponderOnce("eth_blockNumber", `{"jsonrpc":"2.0","id":1,"result":"0x42"}`)
bn, _ := a.Core.GetBlockNumber() // -> 66

// Subscriptions
sub := a.GetProvider().(types.ISubscribeProvider)
sub.Subscribe(ctx, ch, "newHeads")
mock.EmitNewHeads(header) // pushed to ch

// Generic push for any subscription kind
mock.Emit("logs", rawJSON)
```

### Key implementation notes

- `Params` decoded as `[]json.RawMessage` in the request struct — eliminates double-unmarshal in subscribe/unsubscribe handlers
- `RegisterResponderOnce` fails fast with `t.Fatalf` on malformed input instead of silently storing bad JSON
- `Close()` explicitly closes hijacked WS connections before `WaitGroup.Wait` — `http.Server.Close` does not close connections after WebSocket upgrade (hijack removes them from server tracking), which caused a race-detector hang
- `Emit(kind, result)` is the generic push primitive; `EmitNewHeads` is a typed wrapper — callers can push logs, `alchemy_minedTransactions`, or any custom kind without modifying the mock

## Test plan

- [x] `go test ./alchemymock/ -race -count=1` green
- [x] Full non-e2e suite green (`just ut`)
- [x] All subtests: regular call, FIFO ordering, multi-method, error on unmocked, single/multiple newHeads

🤖 Generated with [Claude Code](https://claude.com/claude-code)